### PR TITLE
Update tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,95 +3,68 @@ name: tests
 on: [push, pull_request]
 
 jobs:
+
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
-      max-parallel: 4
+      # max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
-        numpy-version: [1.16.6, 1.17.5, 1.18.4]
+        os: [ubuntu]  # Add macos and windows
+        python-version: [3.7, 3.8, 3.9]
+        numpy-version: [1.19.*, 1.20.*, 1.21.*]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+
     - name: Set up ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependences
+
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install numpy==${{ matrix.numpy-version }}
-    - name: Install readtextstream
+        python -m pip install pytest
+        python -m pip install numpy==${{ matrix.numpy-version }}
+
+    - name: Install npreadtext
       run: |
-        # pip install .
-        python setup.py install
+        python -m pip install -e . --verbose
+
     - name: Test with pytest
       run: |
         pytest
 
-  test38:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
-        numpy-version: [1.18.4]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependences
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        pip install numpy==${{ matrix.numpy-version }}
-    - name: Install readtextstream
-      run: |
-        pip install .
-    - name: Test with pytest
-      run: |
-        pytest
-
-  loadtxt:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    strategy:
-      max-parallel: 2
-      matrix:
-        python-version: [3.8]
-        numpy-version: [1.18.4]
-        test-arg: ["numpy.lib.tests.test_io::TestLoadTxt",
-                   "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependences
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        pip install numpy==${{ matrix.numpy-version }}
-    - name: Install readtextstream
-      run: |
-        pip install .
-    - name: Test with pytest
-      run: |
-        python compat/check_loadtxt_compat.py -v 3 -t ${{ matrix.test-arg }}
-
-
-  ctests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
     - name: Run C tests
       run: |
         cd src/ctests
         bash build_runtest.sh
         ./runtests
+
+  loadtxt-compat:
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: true
+    strategy:
+      max-parallel: 2
+      matrix:
+        os: [ubuntu]  # Add macos and windows
+        python-version: [3.9]
+        numpy-version: [1.21.*]
+        test-arg: ["numpy.lib.tests.test_io::TestLoadTxt",
+                   "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+        python -m pip install numpy==${{ matrix.numpy-version }}
+    - name: Install npreadtxt
+      run: |
+        python -m pip install -e . --verbose
+    - name: Test with pytest
+      run: |
+        python compat/check_loadtxt_compat.py -v 3 -t ${{ matrix.test-arg }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ jobs:
         os: [ubuntu]  # Add macos and windows
         python-version: [3.7, 3.8, 3.9]
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
+        compat-test-arg: ["numpy.lib.tests.test_io::TestLoadTxt",
+                          "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"]
+        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_universal_newline,test_binary_load"]
+
     steps:
     - uses: actions/checkout@v2
 
@@ -23,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest hypothesis
         python -m pip install numpy==${{ matrix.numpy-version }}
 
     - name: Install npreadtext
@@ -34,13 +38,17 @@ jobs:
       run: |
         pytest
 
+    - name: loadtxt-compat-regression
+      run: |
+        python compat/check_loadtxt_compat.py -v 3 -t ${{ matrix.compat-test-arg }} --ignore ${{ matrix.compat-test-ignore }}
+
     - name: Run C tests
       run: |
         cd src/ctests
         bash build_runtest.sh
         ./runtests
 
-  loadtxt-compat:
+  loadtxt-full-compat:
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: true
     strategy:
@@ -60,7 +68,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install pytest hypothesis
         python -m pip install numpy==${{ matrix.numpy-version }}
     - name: Install npreadtxt
       run: |

--- a/compat/check_loadtxt_compat.py
+++ b/compat/check_loadtxt_compat.py
@@ -29,7 +29,20 @@ if __name__ == "__main__":
                     'Default is 1.')
     parser.add_argument('-v', '--verbose', type=int, choices=[1, 2, 3],
                         default=1, help=verbose_help)
+    ignore_help = (
+        'comma-separated list of individual tests to ignore.\n\n'
+        'For example: To run all the tests in TestLoadTxt *except* for '
+        '`test_max_rows` and `test_1D`::\n\n'
+        '  check_loadtxt_compat.py -t numpy.lib.tests.test_io::TestLoadTxt '
+        '--ignore="test_max_rows,test_1D"\n'
+    )
+    parser.add_argument('-i', '--ignore', type=str, default='', help=ignore_help)
 
     args = parser.parse_args()
 
-    np.test(verbose=args.verbose, tests=[args.test])
+    # Convert --ignore str to extra_argv input of np.test via pytest -k flag
+    extra_argv = None
+    if args.ignore:
+        extra_argv = [f'-k not {args.ignore.replace(",", " and not ")}']
+
+    np.test(verbose=args.verbose, tests=[args.test], extra_argv=extra_argv)


### PR DESCRIPTION
The two main changes are:
 1. Updates Python/numpy versions in testing matrix
 2. Adds more stringent np.loadtxt compatibility tests

This PR also reorganizes the test suite so that macos and windows jobs can be added easily, though #3 and #4 should be fixed before these jobs are added.

Re: point 2 - Previously, the CI ran the np.loadtxt test suite in a job that was allowed to fail because there are some tests that fail (8 at current count) that `npreadtext._loadtxt` is not yet fuly compatible with `np.loadtxt`. The problem with this is that if other compat tests that had previously been passing failed because of new changes, it would be difficult to catch this in CI.

I've refactored the compatibility tests so that there are two separate jobs running. The first includes all the compatibility tests that are expected to pass. If any of these fail, the CI will fail as that would indicate a regression. The second job is the same as before - run the full compatibility suite and pass no matter what. Note that individual tests from `numpy.lib.test_io` that are currently failing are excluded by name --- as PRs are submitted to fix these compat issues, the corresponding tests should be removed from the `compat-test-ignore` parameter in CI.

Note - when merging it would be nice to preserve both commits, so please don't squash :)