### PR TITLE
loadtxt compatibility: handle byte converters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
         compat-test-arg: ["numpy.lib.tests.test_io::TestLoadTxt",
                           "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"]
-        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_universal_newline,test_binary_load"]
+        compat-test-ignore: [",test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_universal_newline,test_binary_load"]
 
     steps:
     - uses: actions/checkout@v2

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -167,12 +167,6 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                 raise TypeError('values of the converters dictionary must '
                                 'be callable, but the value associated with '
                                 f'the key {key!r} is not')
-            if byte_converters:
-                def tobytes_first(x, conv):
-                    if isinstance(x, bytes):
-                        return conv(x)
-                    return conv(x.encode("latin1"))
-                converters[key] = functools.partial(tobytes_first, func)
 
     if ndmin not in [None, 0, 1, 2]:
         raise ValueError(f'ndmin must be None, 0, 1, or 2; got {ndmin}')

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -81,7 +81,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
     encoding : str, optional
         Encoding used to decode the inputfile. The special value 'bytes'
         (the default) enables backwards-compatible behavior for `converters`,
-        ensuring that inputs to the converter functions are `latin1`-encoded
+        ensuring that inputs to the converter functions are encoded
         bytes objects. The special value 'bytes' has no additional effect if 
         ``converters=None``. If encoding is ``'bytes'`` or ``None``, the
         default system encoding is used.

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -1,7 +1,7 @@
 
 import os
 import codecs
-from collections.abc import Iterable
+import types
 import functools
 import io
 from pathlib import Path
@@ -218,7 +218,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                           converters=converters,
                                           dtype=dtype,
                                           codes=codes, sizes=sizes,
-                                          encoding=encoding)
+                                          encoding=encoding,
+                                          byte_converters=byte_converters)
         else:
             f = np.lib._datasource.open(fname, 'rt', encoding=encoding)
             try:
@@ -232,7 +233,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                                  max_rows=max_rows,
                                                  converters=converters,
                                                  dtype=dtype, codes=codes,
-                                                 sizes=sizes, encoding=enc)
+                                                 sizes=sizes, encoding=enc,
+                                                 byte_converters=byte_converters)
             finally:
                 f.close()
     elif isinstance(file, Path):
@@ -248,7 +250,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                              converters=converters,
                                              dtype=dtype,
                                              codes=codes, sizes=sizes,
-                                             encoding=enc)
+                                             encoding=enc,
+                                             byte_converters=byte_converters)
     elif isinstance(file, types.GeneratorType):
         if dtype is None:
             raise ValueError('dtype must be given when reading from '
@@ -266,7 +269,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                          converters=converters,
                                          dtype=dtype,
                                          codes=codes, sizes=sizes,
-                                         encoding=enc)
+                                         encoding=enc,
+                                         byte_converters=byte_converters)
     else:
         # Assume file is a file object.
         enc = encoding.encode('ascii') if encoding is not None else None
@@ -278,7 +282,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                          max_rows=max_rows,
                                          converters=converters,
                                          dtype=dtype, codes=codes, sizes=sizes,
-                                         encoding=enc)
+                                         encoding=enc,
+                                         byte_converters=byte_converters)
 
     if ndmin is not None:
         # Handle non-None ndmin like np.loadtxt.  Might change this eventually?

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -2,8 +2,6 @@
 import os
 import codecs
 import types
-import functools
-import io
 from pathlib import Path
 import operator
 import numpy as np
@@ -82,7 +80,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
         Encoding used to decode the inputfile. The special value 'bytes'
         (the default) enables backwards-compatible behavior for `converters`,
         ensuring that inputs to the converter functions are encoded
-        bytes objects. The special value 'bytes' has no additional effect if 
+        bytes objects. The special value 'bytes' has no additional effect if
         ``converters=None``. If encoding is ``'bytes'`` or ``None``, the
         default system encoding is used.
 

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -215,21 +215,21 @@ def test_bad_values(dtype):
 def test_converters():
     txt = StringIO('1.5,2.5\n3.0,XXX\n5.5,6.0')
     conv = {-1: lambda s: np.nan if s == 'XXX' else float(s)}
-    a = read(txt, dtype=np.float64, converters=conv)
+    a = read(txt, dtype=np.float64, converters=conv, encoding=None)
     assert_equal(a, [[1.5, 2.5], [3.0, np.nan], [5.5, 6.0]])
 
 
 def test_converters_and_usecols():
     txt = StringIO('1.5,2.5,3.5\n3.0,4.0,XXX\n5.5,6.0,7.5\n')
     conv = {-1: lambda s: np.nan if s == 'XXX' else float(s)}
-    a = read(txt, dtype=np.float64, converters=conv, usecols=[0, 2])
+    a = read(txt, dtype=np.float64, converters=conv, usecols=[0, 2], encoding=None)
     assert_equal(a, [[1.5, 3.5], [3.0, np.nan], [5.5, 7.5]])
 
 
 def test_unicode_with_converter():
     txt = StringIO('cat,dog\nαβγ,δεζ\nabc,def\n')
     conv = {0: lambda s: s.upper()}
-    a = read(txt, dtype=np.dtype('U12'), converters=conv)
+    a = read(txt, dtype=np.dtype('U12'), converters=conv, encoding=None)
     assert_equal(a, [['CAT', 'dog'], ['ΑΒΓ', 'δεζ'], ['ABC', 'def']])
 
 

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -243,6 +243,21 @@ def test_converter_with_structured_dtype():
     assert_equal(a, expected)
 
 
+def test_converter_with_unicode_dtype():
+    """
+    With the default 'bytes' encoding, tokens are encoded prior to converting.
+    This means that the output of the converter may be bytes instead of
+    unicode as expected by `read_rows`.
+    This test checks that outputs from the above scenario are properly
+    decoded before parsing by `read_rows`.
+    """
+    txt = StringIO('abc,def\nrst,xyz')
+    conv = {col: bytes.upper for col in range(2)}
+    a = read(txt, dtype=np.dtype('U3'), converters=conv)
+    expected = np.array([['ABC', 'DEF'], ['RST', 'XYZ']])
+    assert_equal(a, expected)
+
+
 @pytest.mark.parametrize('dtype, actual_dtype', [('S', np.dtype('S5')),
                                                  ('U', np.dtype('U5'))])
 def test_string_no_length_given(dtype, actual_dtype):

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -294,7 +294,7 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
                              "usecols", "skiprows",
                              "max_rows", "converters",
                              "dtype", "codes", "sizes",
-                             "encoding", NULL};
+                             "encoding", "byte_converters", NULL};
     char *filename;
     char *delimiter = ",";
     char *comment = "#";
@@ -313,6 +313,8 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *sizes;
     PyObject *encoding;
 
+    int byte_converters = false;
+
     char *codes_ptr = NULL;
     int32_t *sizes_ptr = NULL;
 
@@ -321,11 +323,12 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *arr = NULL;
     int num_dtype_fields;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|$ssssssOiiOOOOO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|$ssssssOiiOOOOOp", kwlist,
                                      &filename, &delimiter, &comment, &quote,
                                      &decimal, &sci, &imaginary_unit, &usecols, &skiprows,
                                      &max_rows, &converters,
-                                     &dtype, &codes, &sizes, &encoding)) {
+                                     &dtype, &codes, &sizes, &encoding,
+                                     &byte_converters)) {
         return NULL;
     }
 
@@ -342,6 +345,7 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
     pc.ignore_trailing_spaces = false;
     pc.ignore_blank_lines = true;
     pc.strict_num_fields = false;
+    pc.byte_converters = byte_converters;
 
     if (dtype == Py_None) {
         num_dtype_fields = -1;
@@ -383,7 +387,7 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
                              "usecols", "skiprows",
                              "max_rows", "converters",
                              "dtype", "codes", "sizes",
-                             "encoding", NULL};
+                             "encoding", "byte_converters", NULL};
     PyObject *file;
     char *delimiter = ",";
     char *comment = "#";
@@ -401,6 +405,8 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *sizes;
     PyObject *encoding;
 
+    int byte_converters = false;
+
     char *codes_ptr = NULL;
     int32_t *sizes_ptr = NULL;
 
@@ -408,11 +414,12 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *arr = NULL;
     int num_dtype_fields;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$ssssssOiiOOOOO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$ssssssOiiOOOOOp", kwlist,
                                      &file, &delimiter, &comment, &quote,
                                      &decimal, &sci, &imaginary_unit, &usecols, &skiprows,
                                      &max_rows, &converters,
-                                     &dtype, &codes, &sizes, &encoding)) {
+                                     &dtype, &codes, &sizes, &encoding,
+                                     &byte_converters)) {
         return NULL;
     }
 
@@ -429,6 +436,7 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     pc.ignore_trailing_spaces = false;
     pc.ignore_blank_lines = true;
     pc.strict_num_fields = false;
+    pc.byte_converters = byte_converters;
 
     if (dtype == Py_None) {
         num_dtype_fields = -1;

--- a/src/parser_config.c
+++ b/src/parser_config.c
@@ -17,7 +17,8 @@ parser_config default_parser_config(void)
     config.ignore_leading_spaces = true;
     config.ignore_trailing_spaces = true;
     config.strict_num_fields = true;
-    confgi.allow_float_for_int = true;
+    config.allow_float_for_int = true;
+    config.byte_converters = false;
 
     return config;
 }

--- a/src/parser_config.h
+++ b/src/parser_config.h
@@ -100,6 +100,13 @@ typedef struct _parser_config {
       */
      bool allow_float_for_int;
 
+     /*
+      * If true, encode fields prior to applying converter functions.
+      * This preserves backwards compatiblity with np.loadtxt behavior in
+      * Python 2, where converter functions could be used to decode values.
+      */
+     bool byte_converters;
+
 } parser_config;
 
 parser_config default_parser_config(void);

--- a/src/rows.c
+++ b/src/rows.c
@@ -57,7 +57,7 @@ PyObject *call_converter_function(PyObject *func, char32_t *token, bool byte_con
     while (token[tokenlen]) {
         ++tokenlen;
     }
- 
+
     // Convert token to a Python unicode object
     PyObject *s = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, token, tokenlen);
     if (s == NULL) {
@@ -398,7 +398,7 @@ void *read_rows(stream *s, int *nrows,
         else {
             // *Not* the first line...
             if (track_string_size) {
-                size_t new_itemsize;
+                size_t new_itemsize, maxlen;
                 // typecode must be 'S' or 'U'.
                 // Find the maximum field length in the current line.
                 if (converters != Py_None) {
@@ -411,8 +411,6 @@ void *read_rows(stream *s, int *nrows,
                     maxlen = max_token_len(result, actual_num_fields,
                                                   usecols, num_usecols);
                 }
-                size_t maxlen = max_token_len(result, actual_num_fields,
-                                              usecols, num_usecols);
                 new_itemsize = (field_types[0].typecode == 'S') ? maxlen : 4*maxlen;
                 if (new_itemsize > field_types[0].itemsize) {
                     // There is a field in this row whose length is

--- a/src/rows.c
+++ b/src/rows.c
@@ -61,15 +61,14 @@ PyObject *call_converter_function(PyObject *func, char32_t *token, bool byte_con
     // Convert token to a Python unicode object
     PyObject *s = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, token, tokenlen);
     if (s == NULL) {
-        // fprintf(stderr, "*** PyUnicode_FromKindAndData failed ***\n");
         return s;
     }
 
     // If byte_converters flag is set, encode prior to calling converter
     if (byte_converters) {
+        // TODO: Is it safe to use the same PyObject to store the encoded result?
         s = PyObject_CallMethod(s, "encode", NULL);
         if (s == NULL) {
-//            fprintf(stderr, "*** encode failed ***\n");
             return s;
         }
     }
@@ -77,9 +76,6 @@ PyObject *call_converter_function(PyObject *func, char32_t *token, bool byte_con
     // Apply converter function
     PyObject *result = PyObject_CallFunctionObjArgs(func, s, NULL);
     Py_DECREF(s);
-//    if (result == NULL) {
-//        fprintf(stderr, "*** PyObject_CallFunctionObjArgs failed ***\n");
-//    }
     return result;
 }
 
@@ -129,21 +125,17 @@ size_t max_token_len_with_converters(char32_t **tokens, int num_tokens,
             PyObject *obj = call_converter_function(conv_funcs[i], tokens[j],
                                                     byte_converters);
             if (obj == NULL) {
-//                fprintf(stderr, "CALL FAILED! strlen(tokens[j]) = %u, tokens[j] = %u\n",
-//                                strlen32(tokens[j]), tokens[j][0]);
                 return NULL;
             }
             // XXX check for obj == NULL!
             PyObject *s = PyObject_Str(obj);
             if (s == NULL) {
-                // fprintf(stderr, "STR FAILED!\n");
                 return NULL;
             }
             Py_DECREF(obj);
             // XXX check for s == NULL!
             Py_ssize_t len = PySequence_Length(s);
             if (len == -1) {
-                // fprintf(stderr, "LEN FAILED!\n");
                 return NULL;
             }
             // XXX check for len == -1

--- a/src/rows.c
+++ b/src/rows.c
@@ -69,7 +69,7 @@ PyObject *call_converter_function(PyObject *func, char32_t *token, bool byte_con
     if (byte_converters) {
         s = PyObject_CallMethod(s, "encode", NULL);
         if (s == NULL) {
-            fprintf(stderr, "*** encode failed ***\n");
+//            fprintf(stderr, "*** encode failed ***\n");
             return s;
         }
     }
@@ -77,9 +77,9 @@ PyObject *call_converter_function(PyObject *func, char32_t *token, bool byte_con
     // Apply converter function
     PyObject *result = PyObject_CallFunctionObjArgs(func, s, NULL);
     Py_DECREF(s);
-    if (result == NULL) {
-        // fprintf(stderr, "*** PyObject_CallFunctionObjArgs failed ***\n");
-    }
+//    if (result == NULL) {
+//        fprintf(stderr, "*** PyObject_CallFunctionObjArgs failed ***\n");
+//    }
     return result;
 }
 
@@ -136,13 +136,15 @@ size_t max_token_len_with_converters(char32_t **tokens, int num_tokens,
             // XXX check for obj == NULL!
             PyObject *s = PyObject_Str(obj);
             if (s == NULL) {
-                fprintf(stderr, "STR FAILED!\n");
+                // fprintf(stderr, "STR FAILED!\n");
+                return NULL;
             }
             Py_DECREF(obj);
             // XXX check for s == NULL!
             Py_ssize_t len = PySequence_Length(s);
             if (len == -1) {
-                fprintf(stderr, "LEN FAILED!\n");
+                // fprintf(stderr, "LEN FAILED!\n");
+                return NULL;
             }
             // XXX check for len == -1
             Py_DECREF(s);

--- a/src/rows.c
+++ b/src/rows.c
@@ -62,8 +62,14 @@ PyObject *call_converter_function(PyObject *func, char32_t *token)
         // fprintf(stderr, "*** PyUnicode_FromKindAndData failed ***\n");
         return s;
     }
-    PyObject *result = PyObject_CallFunctionObjArgs(func, s, NULL);
+    PyObject *b = PyObject_CallMethod(s, "encode", NULL);
+    if (b == NULL) {
+        fprintf(stderr, "*** encode failed ***\n");
+        return b;
+    }
+    PyObject *result = PyObject_CallFunctionObjArgs(func, b, NULL);
     Py_DECREF(s);
+    Py_DECREF(b);
     if (result == NULL) {
         // fprintf(stderr, "*** PyObject_CallFunctionObjArgs failed ***\n");
     }
@@ -115,7 +121,9 @@ size_t max_token_len_with_converters(char32_t **tokens, int num_tokens,
         if (conv_funcs && conv_funcs[j]) {
             PyObject *obj = call_converter_function(conv_funcs[i], tokens[j]);
             if (obj == NULL) {
-                fprintf(stderr, "CALL FAILED!\n");
+//                fprintf(stderr, "CALL FAILED! strlen(tokens[j]) = %u, tokens[j] = %u\n",
+//                                strlen32(tokens[j]), tokens[j][0]);
+                return NULL;
             }
             // XXX check for obj == NULL!
             PyObject *s = PyObject_Str(obj);

--- a/src/rows.c
+++ b/src/rows.c
@@ -764,6 +764,15 @@ void *read_rows(stream *s, int *nrows,
                         Py_ssize_t len;
                         int kind;
                         void *data;
+                        // The value returned by the converter may be a bytes
+                        // object when e.g. `encoding="bytes"`. In this case,
+                        // decode before processing
+                        if (PyBytes_Check(converted)) {
+                            PyObject* converted_unicode = PyObject_CallMethod(
+                                converted, "decode", NULL);
+                            converted = converted_unicode;
+                            Py_DECREF(converted_unicode);
+                        }
                         if (!PyUnicode_Check(converted)) {
                             read_error->error_type = ERROR_BAD_FIELD;
                             break;


### PR DESCRIPTION
`np.loadtxt` allows values read in from file to be encoded/decoded via `converters`. AFAICT this feature is mostly for compatibility with Python 2. The feature is "activated" by passing in a special `'bytes'` keyword to the `encoding` parameter --- `encoding='bytes'` is the default which means this behavior is the default loadtxt behavior.

In order to maintain compatibility with this feature of `np.loadtxt`, this PR mirrors the special handling of the `encoding='bytes'` kwarg. When this value is passed in, a flag is set so that tokens are always encoded (-> bytes) prior to applying the converter functions.

Testing for this behavior is encapsulated in the numpy test suite in `TestLoadTxt::test_converters_decode` and `TestLoadTxt::test_converters_nodecode`. This PR fixes `_loadtxt` for these test cases.