### PR TITLE
STY: Ensure all C-function definitions start with the name

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -27,7 +27,8 @@ typedef struct {
 } integer_range;
 
 
-int enlarge_ranges(int new_num_fields, int num_fields, integer_range **ranges)
+int
+enlarge_ranges(int new_num_fields, int num_fields, integer_range **ranges)
 {
     int nbytes;
     integer_range *new_ranges;
@@ -47,8 +48,10 @@ int enlarge_ranges(int new_num_fields, int num_fields, integer_range **ranges)
     return 0;
 }
 
-int enlarge_type_tracking_arrays(int new_num_fields, int num_fields,
-                                 field_type **types, integer_range **ranges)
+int
+enlarge_type_tracking_arrays(
+        int new_num_fields, int num_fields,
+        field_type **types, integer_range **ranges)
 {
     int status1 = field_types_grow(new_num_fields, num_fields, types);
     int status2 = enlarge_ranges(new_num_fields, num_fields, ranges);
@@ -76,8 +79,9 @@ int enlarge_type_tracking_arrays(int new_num_fields, int num_fields,
  *  ...
  */
 
-int analyze(stream *s, parser_config *pconfig, int skiplines, int numrows,
-            int *p_num_fields, field_type **p_field_types)
+int
+analyze(stream *s, parser_config *pconfig, int skiplines, int numrows,
+        int *p_num_fields, field_type **p_field_types)
 {
     int row_count = 0;
     int num_fields = 0;

--- a/src/analyze.h
+++ b/src/analyze.h
@@ -10,7 +10,8 @@
 #define ANALYZE_FILE_ERROR    -1
 #define ANALYZE_OUT_OF_MEMORY -2
 
-int analyze(stream *s, parser_config *pconfig, int skiplines, int numrows,
-            int *num_fields, field_type **field_types);
+int
+analyze(stream *s, parser_config *pconfig, int skiplines, int numrows,
+        int *p_num_fields, field_type **p_field_types);
 
 #endif

--- a/src/char32utils.c
+++ b/src/char32utils.c
@@ -2,7 +2,8 @@
 #include "char32utils.h"
 
 
-size_t strlen32(char32_t *s)
+size_t
+strlen32(char32_t *s)
 {
     size_t count = 0;
     while (*s) {
@@ -13,7 +14,8 @@ size_t strlen32(char32_t *s)
 }
 
 
-long long strtoll32(char32_t *s, char32_t **p)
+long long
+strtoll32(char32_t *s, char32_t **p)
 {
     long long result = 0;
     int sign = 1;

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -11,8 +11,9 @@
 #include "char32utils.h"
 
 double
-_Py_dg_strtod_modified(const char32_t *s00, char32_t **se, int *error,
-                       char32_t decimal, char32_t sci, bool skip_trailing);
+_Py_dg_strtod_modified(
+        const char32_t *s00, char32_t **se, int *error,
+        char32_t decimal, char32_t sci, bool skip_trailing);
 
 /*
  *  `item` must be the nul-terminated string that is to be
@@ -30,7 +31,8 @@ _Py_dg_strtod_modified(const char32_t *s00, char32_t **se, int *error,
  *
  */
 
-bool to_double(char32_t *item, double *p_value, char32_t sci, char32_t decimal)
+bool
+to_double(char32_t *item, double *p_value, char32_t sci, char32_t decimal)
 {
     char32_t *p_end;
     int error;
@@ -41,9 +43,11 @@ bool to_double(char32_t *item, double *p_value, char32_t sci, char32_t decimal)
 }
 
 
-bool to_complex(char32_t *item, double *p_real, double *p_imag,
-                char32_t sci, char32_t decimal, char32_t imaginary_unit,
-                bool allow_parens)
+bool
+to_complex(
+        char32_t *item, double *p_real, double *p_imag,
+        char32_t sci, char32_t decimal, char32_t imaginary_unit,
+        bool allow_parens)
 {
     char32_t *p_end;
     int error;
@@ -96,7 +100,8 @@ bool to_complex(char32_t *item, double *p_real, double *p_imag,
 }
 
 
-bool to_longlong(char32_t *item, long long *p_value)
+bool
+to_longlong(char32_t *item, long long *p_value)
 {
     char32_t *p_end;
 

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -6,10 +6,16 @@
 #include "typedefs.h"
 
 
-bool to_double(char32_t *item, double *p_value, char32_t sci, char32_t decimal);
-bool to_complex(char32_t *item, double *p_real, double *p_imag,
-                char32_t sci, char32_t decimal, char32_t imaginary_unit,
-                bool allow_parens);
-bool to_longlong(char32_t *item, long long *p_value);
+bool
+to_double(char32_t *item, double *p_value, char32_t sci, char32_t decimal);
+
+bool
+to_complex(
+        char32_t *item, double *p_real, double *p_imag,
+        char32_t sci, char32_t decimal, char32_t imaginary_unit,
+        bool allow_parens);
+
+bool
+to_longlong(char32_t *item, long long *p_value);
 
 #endif

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -11,9 +11,8 @@
 #include "field_types.h"
 
 
-field_type *field_types_create(int num_field_types,
-                               const char *codes,
-                               const int32_t *sizes)
+field_type *
+field_types_create(int num_field_types, const char *codes, const int32_t *sizes)
 {
     field_type *ft;
 
@@ -28,7 +27,8 @@ field_type *field_types_create(int num_field_types,
     return ft;
 }
 
-void field_types_fprintf(FILE *out, int num_field_types, const field_type *ft)
+void
+field_types_fprintf(FILE *out, int num_field_types, const field_type *ft)
 {
     for (int i = 0; i < num_field_types; ++i) {
         fprintf(out, "ft[%d].typecode = %c, .itemsize = %d\n",
@@ -37,7 +37,8 @@ void field_types_fprintf(FILE *out, int num_field_types, const field_type *ft)
 }
 
 
-bool field_types_is_homogeneous(int num_field_types, const field_type *ft)
+bool
+field_types_is_homogeneous(int num_field_types, const field_type *ft)
 {
     bool homogeneous = true;
     for (int k = 1; k < num_field_types; ++k) {
@@ -51,7 +52,8 @@ bool field_types_is_homogeneous(int num_field_types, const field_type *ft)
 }
 
 
-int32_t field_types_total_size(int num_field_types, const field_type *ft)
+int32_t
+field_types_total_size(int num_field_types, const field_type *ft)
 {
     int32_t size = 0;
     for (int k = 0; k < num_field_types; ++k) {
@@ -66,7 +68,8 @@ int32_t field_types_total_size(int num_field_types, const field_type *ft)
 // previously malloc'ed.
 // The function assumes that new_num_field_types > num_field_types.
 //
-int field_types_grow(int new_num_field_types, int num_field_types, field_type **ft)
+int
+field_types_grow(int new_num_field_types, int num_field_types, field_type **ft)
 {
     size_t nbytes;
     field_type *new_ft;
@@ -119,8 +122,10 @@ char *typecode_to_str(char typecode)
 // If cols == NULL, it is not used.  Otherwise it is an array
 // of length num_cols that gives the index into ft to use.
 //
-char *field_types_build_str(int num_cols, const int32_t *cols, bool homogeneous,
-                            const field_type *ft)
+char *
+field_types_build_str(
+        int num_cols, const int32_t *cols, bool homogeneous,
+        const field_type *ft)
 {
     char *dtypestr;
     size_t len;
@@ -178,7 +183,8 @@ char *field_types_build_str(int num_cols, const int32_t *cols, bool homogeneous,
 
 #ifdef TESTMAIN
 
-void show_field_types(int num_fields, field_type *ft)
+void
+show_field_types(int num_fields, field_type *ft)
 {
     field_types_fprintf(stdout, num_fields, ft);
 
@@ -195,7 +201,8 @@ void show_field_types(int num_fields, field_type *ft)
 }
 
 
-int main(int argc, char *argv[])
+int
+main(int argc, char *argv[])
 {
     char *codes = "ffHHSU";
     int32_t sizes[] = {8, 8, 2, 2, 4, 48};

--- a/src/field_types.h
+++ b/src/field_types.h
@@ -35,14 +35,27 @@ typedef struct _field_type {
 } field_type;
 
 
-field_type *field_types_create(int num_field_types, const char *codes, const int *sizes);
-void field_types_fprintf(FILE *out, int num_field_types, const field_type *ft);
-bool field_types_is_homogeneous(int num_field_types, const field_type *ft);
-int32_t field_types_total_size(int num_field_types, const field_type *ft);
-int field_types_grow(int new_num_field_types, int num_field_types, field_type **ft);
-char *field_types_build_str(int num_cols, const int32_t *cols, bool homogeneous,
-                            const field_type *ft);
+field_type *
+field_types_create(int num_field_types, const char *codes, const int *sizes);
 
-char *typecode_to_str(char typecode);
+void
+field_types_fprintf(FILE *out, int num_field_types, const field_type *ft);
+
+bool
+field_types_is_homogeneous(int num_field_types, const field_type *ft);
+
+int32_t
+field_types_total_size(int num_field_types, const field_type *ft);
+
+int
+field_types_grow(int new_num_field_types, int num_field_types, field_type **ft);
+
+char *
+field_types_build_str(
+        int num_cols, const int32_t *cols, bool homogeneous,
+        const field_type *ft);
+
+char *
+typecode_to_str(char typecode);
 
 #endif

--- a/src/max_token_len.c
+++ b/src/max_token_len.c
@@ -3,7 +3,8 @@
 #include "typedefs.h"
 
 
-size_t max_token_len(size_t num_fields, char32_t **tokens)
+size_t
+max_token_len(size_t num_fields, char32_t **tokens)
 {
     size_t max_len = 0;
     size_t last_len;

--- a/src/max_token_len.h
+++ b/src/max_token_len.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include "typedefs.h"
 
-size_t max_token_len(size_t num_fields, char32_t **tokens);
+size_t
+max_token_len(size_t num_fields, char32_t **tokens);
 
 #endif

--- a/src/parser_config.c
+++ b/src/parser_config.c
@@ -2,7 +2,8 @@
 #include <stdbool.h>
 #include "parser_config.h"
 
-parser_config default_parser_config(void)
+parser_config
+default_parser_config(void)
 {
     parser_config config;
 

--- a/src/parser_config.h
+++ b/src/parser_config.h
@@ -102,6 +102,7 @@ typedef struct _parser_config {
 
 } parser_config;
 
-parser_config default_parser_config(void);
+parser_config
+default_parser_config(void);
 
 #endif

--- a/src/rows.c
+++ b/src/rows.c
@@ -31,8 +31,9 @@
 //
 // If num_field_types is not 1, actual_num_fields must equal num_field_types.
 //
-size_t compute_row_size(int actual_num_fields,
-                        int num_field_types, field_type *field_types)
+size_t
+compute_row_size(
+        int actual_num_fields, int num_field_types, field_type *field_types)
 {
     size_t row_size;
 
@@ -51,7 +52,8 @@ size_t compute_row_size(int actual_num_fields,
 }
 
 
-PyObject *call_converter_function(PyObject *func, char32_t *token)
+PyObject *
+call_converter_function(PyObject *func, char32_t *token)
 {
     Py_ssize_t tokenlen = 0;
     while (token[tokenlen]) {
@@ -74,8 +76,9 @@ PyObject *call_converter_function(PyObject *func, char32_t *token)
  *  Find the length of the longest token.
  */
 
-size_t max_token_len(char32_t **tokens, int num_tokens,
-                     int32_t *usecols, int num_usecols)
+size_t
+max_token_len(
+        char32_t **tokens, int num_tokens, int32_t *usecols, int num_usecols)
 {
     size_t maxlen = 0;
     for (size_t i = 0; i < num_tokens; ++i) {
@@ -96,9 +99,10 @@ size_t max_token_len(char32_t **tokens, int num_tokens,
 
 
 // WIP...
-size_t max_token_len_with_converters(char32_t **tokens, int num_tokens,
-                                     int32_t *usecols, int num_usecols,
-                                     PyObject **conv_funcs)
+size_t
+max_token_len_with_converters(
+        char32_t **tokens, int num_tokens, int32_t *usecols,
+        int num_usecols, PyObject **conv_funcs)
 {
     size_t maxlen = 0;
     size_t m;
@@ -146,8 +150,10 @@ size_t max_token_len_with_converters(char32_t **tokens, int num_tokens,
 /*
  *  Create the array of converter functions from the Python converters dict.
  */
-PyObject **create_conv_funcs(PyObject *converters, int32_t *usecols, int num_usecols,
-                             int current_num_fields, read_error_type *read_error)
+PyObject **
+create_conv_funcs(
+        PyObject *converters, int32_t *usecols, int num_usecols,
+        int current_num_fields, read_error_type *read_error)
 {
     PyObject **conv_funcs = NULL;
     size_t j, k;
@@ -221,15 +227,12 @@ PyObject **create_conv_funcs(PyObject *converters, int32_t *usecols, int num_use
  *      Information about errors detected in read_rows()
  */
 
-void *read_rows(stream *s, int *nrows,
-                int num_field_types, field_type *field_types,
-                parser_config *pconfig,
-                int32_t *usecols, int num_usecols,
-                int skiplines,
-                PyObject *converters,
-                void *data_array,
-                int *num_cols,
-                read_error_type *read_error)
+void *
+read_rows(stream *s,
+        int *nrows, int num_field_types, field_type *field_types,
+        parser_config *pconfig, int32_t *usecols, int num_usecols,
+        int skiplines, PyObject *converters, void *data_array,
+        int *num_cols, read_error_type *read_error)
 {
     char *data_ptr;
     int current_num_fields;

--- a/src/rows.h
+++ b/src/rows.h
@@ -32,14 +32,11 @@ int count_fields(FILE *f, parser_config *pconfig, int skiprows);
 int count_rows(FILE *f, parser_config *pconfig);
 */
 
-void *read_rows(stream *s, int *nrows,
-                int num_field_types, field_type *field_types,
-                parser_config *pconfig,
-                int *usecols, int num_usecols,
-                int skiplines,
-                PyObject *converters,
-                void *data_array,
-                int *num_cols,
-                read_error_type *read_error);
+void *
+read_rows(stream *s,
+        int *nrows, int num_field_types, field_type *field_types,
+        parser_config *pconfig, int32_t *usecols, int num_usecols,
+        int skiplines, PyObject *converters, void *data_array,
+        int *num_cols, read_error_type *read_error);
 
 #endif

--- a/src/str_to.c
+++ b/src/str_to.c
@@ -13,7 +13,9 @@
  *  On success, *error is zero.
  *  If the conversion fails, *error is nonzero, and the return value is 0.
  */
-int64_t str_to_int64(const char32_t *p_item, int64_t int_min, int64_t int_max, int *error)
+int64_t
+str_to_int64(
+        const char32_t *p_item, int64_t int_min, int64_t int_max, int *error)
 {
     const char32_t *p = (const char32_t *) p_item;
     bool isneg = 0;
@@ -101,7 +103,8 @@ int64_t str_to_int64(const char32_t *p_item, int64_t int_min, int64_t int_max, i
  *  On success, *error is zero.
  *  If the conversion fails, *error is nonzero, and the return value is 0.
  */
-uint64_t str_to_uint64(const char32_t *p_item, uint64_t uint_max, int *error)
+uint64_t
+str_to_uint64(const char32_t *p_item, uint64_t uint_max, int *error)
 {
     const char32_t *p = (const char32_t *) p_item;
     uint64_t number = 0;

--- a/src/str_to.h
+++ b/src/str_to.h
@@ -12,7 +12,11 @@
 #define ERROR_INVALID_CHARS  3
 #define ERROR_MINUS_SIGN     4
 
-int64_t str_to_int64(const char32_t *p_item, int64_t int_min, int64_t int_max, int *error);
-uint64_t str_to_uint64(const char32_t *p_item, uint64_t uint_max, int *error);
+int64_t
+str_to_int64(
+        const char32_t *p_item, int64_t int_min, int64_t int_max, int *error);
+
+uint64_t
+str_to_uint64(const char32_t *p_item, uint64_t uint_max, int *error);
 
 #endif

--- a/src/str_to_double.c
+++ b/src/str_to_double.c
@@ -21,8 +21,10 @@ extern double pow10table_size;
 extern double pow10table[];
 
 
-double str_to_double(const char32_t *str, char32_t **end, int *error,
-                     char32_t decimal, char32_t sci, bool skip_trailing)
+double
+str_to_double(
+        const char32_t *str, char32_t **end, int *error,
+        char32_t decimal, char32_t sci, bool skip_trailing)
 {
     double value;
     int negative, negative_exp;

--- a/src/str_to_int.c
+++ b/src/str_to_int.c
@@ -8,7 +8,8 @@
 
 
 #define DECLARE_TO_INT(intw, INT_MIN, INT_MAX)                                  \
-    intw##_t to_##intw(char32_t *field, parser_config *pconfig, int *error)     \
+    intw##_t                                                                        \
+    to_##intw(char32_t *field, parser_config *pconfig, int *error)                  \
     {                                                                               \
         intw##_t x;                                                                 \
         int ierror = 0;                                                             \
@@ -36,7 +37,8 @@
     }                                                                               \
 
 #define DECLARE_TO_UINT(uintw, UINT_MAX)                                            \
-    uintw##_t to_##uintw(char32_t *field, parser_config *pconfig, int *error)       \
+    uintw##_t                                                                       \
+    to_##uintw(char32_t *field, parser_config *pconfig, int *error)                 \
     {                                                                               \
         uintw##_t x;                                                                \
         int ierror = 0;                                                             \

--- a/src/stream_file.c
+++ b/src/stream_file.c
@@ -222,7 +222,8 @@ uint32_t fb_skipline(void *fb)
  *  The return value is 0 if no errors occurred.
  */
 
-uint32_t fb_skiplines(void *fb, int num_lines)
+uint32_t
+fb_skiplines(void *fb, int num_lines)
 {
     int32_t status;
     char32_t c;
@@ -245,12 +246,14 @@ uint32_t fb_skiplines(void *fb, int num_lines)
     return 0;
 }
 
-long int fb_tell(void *fb)
+long int
+fb_tell(void *fb)
 {
     return ftell(FB(fb)->file);
 }
 
-int fb_seek(void *fb, long int pos)
+int
+fb_seek(void *fb, long int pos)
 {
     // Not correct, but for now, assume pos == 0.
     FB(fb)->line_number = 1;
@@ -261,8 +264,8 @@ int fb_seek(void *fb, long int pos)
     return fseek(FB(fb)->file, pos, SEEK_SET);
 }
 
-static
-int stream_del(stream *strm, int restore)
+static int
+stream_del(stream *strm, int restore)
 {
     file_buffer *fb = (file_buffer *) (strm->stream_data);
 
@@ -288,7 +291,8 @@ int stream_del(stream *strm, int restore)
  *  Returns NULL if the memory allocation fails.
  */
 
-stream *stream_file(FILE *f, int buffer_size)
+stream *
+stream_file(FILE *f, int buffer_size)
 {
     file_buffer *fb;
     stream *strm;
@@ -345,7 +349,8 @@ stream *stream_file(FILE *f, int buffer_size)
 }
 
 
-stream *stream_file_from_filename(char *filename, int buffer_size)
+stream *
+stream_file_from_filename(char *filename, int buffer_size)
 {
     FILE *fp;
 

--- a/src/stream_file.h
+++ b/src/stream_file.h
@@ -3,7 +3,10 @@
 
 #include "stream.h"
 
-stream *stream_file(FILE *f, int buffer_size);
-stream *stream_file_from_filename(char *filename, int buffer_size);
+stream *
+stream_file(FILE *f, int buffer_size);
+
+stream *
+stream_file_from_filename(char *filename, int buffer_size);
 
 #endif

--- a/src/stream_python_file_by_line.c
+++ b/src/stream_python_file_by_line.c
@@ -72,8 +72,8 @@ typedef struct _python_file_by_line {
 
 #define FB(fb)  ((python_file_by_line *)fb)
 
-static
-int32_t fb_line_number(void *fb)
+static int32_t
+fb_line_number(void *fb)
 {
     return FB(fb)->line_number;
 }
@@ -87,8 +87,8 @@ int32_t fb_line_number(void *fb)
  *  Returns STREAM_ERROR on error.
  */
 
-static
-uint32_t _fb_load(void *fb)
+static uint32_t
+_fb_load(void *fb)
 {
     //printf("_fb_load: starting\n");
     //printf("FB(fb)->reached_eof = %d\n", FB(fb)->reached_eof);
@@ -160,8 +160,8 @@ uint32_t _fb_load(void *fb)
  *  When '\n' is returned, fb->line_number is incremented.
  */
 
-static
-char32_t fb_fetch(void *fb)
+static char32_t
+fb_fetch(void *fb)
 {
     char32_t c;
   
@@ -192,8 +192,8 @@ char32_t fb_fetch(void *fb)
  *  If the next two characters in the buffer are "\r\n", '\n' is returned.
  */
 
-static
-char32_t fb_next(void *fb)
+static char32_t
+fb_next(void *fb)
 {
     char32_t c;
 
@@ -218,8 +218,8 @@ char32_t fb_next(void *fb)
  *  The return value is 0 if no errors occurred.
  */
 
-static
-uint32_t fb_skipline(void *fb)
+static uint32_t
+fb_skipline(void *fb)
 {
     char32_t c;
 
@@ -250,8 +250,8 @@ uint32_t fb_skipline(void *fb)
  *  The return value is 0 if no errors occurred.
  */
 
-static
-uint32_t fb_skiplines(void *fb, int num_lines)
+static uint32_t
+fb_skiplines(void *fb, int num_lines)
 {
     int32_t status;
     char32_t c;
@@ -274,9 +274,9 @@ uint32_t fb_skiplines(void *fb, int num_lines)
     return 0;
 }
 
-// XXX Is long int really the correct type?
-static
-long int fb_tell(void *fb)
+// XXX Is long int really the correct type? Probably no, should be `npy_off_t`
+static long int
+fb_tell(void *fb)
 {
     long int pos;
     PyObject *obj = PyObject_Call(FB(fb)->tell, FB(fb)->empty_tuple, NULL);
@@ -285,8 +285,8 @@ long int fb_tell(void *fb)
     return pos;
 }
 
-static
-int fb_seek(void *fb, long int pos)
+static int
+fb_seek(void *fb, long int pos)
 {
     int status = 0;
 
@@ -303,8 +303,8 @@ int fb_seek(void *fb, long int pos)
     return status;
 }
 
-static
-int stream_del(stream *strm, int restore)
+static int
+stream_del(stream *strm, int restore)
 {
     python_file_by_line *fb = (python_file_by_line *) (strm->stream_data);
 
@@ -333,7 +333,8 @@ int stream_del(stream *strm, int restore)
 }
 
 
-stream *stream_python_file_by_line(PyObject *obj, PyObject *encoding)
+stream *
+stream_python_file_by_line(PyObject *obj, PyObject *encoding)
 {
     python_file_by_line *fb;
     stream *strm;

--- a/src/stream_python_file_by_line.h
+++ b/src/stream_python_file_by_line.h
@@ -7,6 +7,7 @@
 
 #include "stream.h"
 
-stream *stream_python_file_by_line(PyObject *obj, PyObject *encoding);
+stream *
+stream_python_file_by_line(PyObject *obj, PyObject *encoding);
 
 #endif

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -77,11 +77,10 @@
  *  * The row has more fields than MAX_NUM_COLUMNS.
  */
 
-static char32_t **tokenize_sep(stream *s, char32_t *word_buffer,
-                               int word_buffer_size,
-                               parser_config *pconfig,
-                               int *p_num_fields,
-                               int *p_error_type)
+static char32_t **
+tokenize_sep(stream *s,
+        char32_t *word_buffer, int word_buffer_size,
+        parser_config *pconfig, int *p_num_fields, int *p_error_type)
 {
     int n;
     char32_t c;
@@ -243,10 +242,10 @@ static char32_t **tokenize_sep(stream *s, char32_t *word_buffer,
  *      This needs to be refined.
  */
 
-static char32_t **tokenize_ws(stream *s, char32_t *word_buffer, int word_buffer_size,
-                              parser_config *pconfig,
-                              int *p_num_fields,
-                              int *p_error_type)
+static char32_t **
+tokenize_ws(stream *s,
+        char32_t *word_buffer, int word_buffer_size,
+        parser_config *pconfig, int *p_num_fields, int *p_error_type)
 {
     int n;
     char32_t c;
@@ -407,8 +406,10 @@ static char32_t **tokenize_ws(stream *s, char32_t *word_buffer, int word_buffer_
 }
 
 
-char32_t **tokenize(stream *s, char32_t *word_buffer, int word_buffer_size,
-                    parser_config *pconfig, int *p_num_fields, int *p_error_type)
+char32_t **
+tokenize(stream *s,
+        char32_t *word_buffer, int word_buffer_size,
+        parser_config *pconfig, int *p_num_fields, int *p_error_type)
 {
     char32_t **result;
 

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -6,9 +6,9 @@
 #include "stream.h"
 #include "parser_config.h"
 
-char32_t **tokenize(stream *fb, char32_t *word_buffer, int word_buffer_size,
-                    parser_config *pconfg,
-                    int *p_num_fields,
-                    int *p_error_type);
+char32_t
+**tokenize(stream *fb,
+        char32_t *word_buffer, int word_buffer_size,
+        parser_config *pconfg, int *p_num_fields, int *p_error_type);
 
 #endif

--- a/src/type_inference.c
+++ b/src/type_inference.c
@@ -54,9 +54,10 @@ as missing data.
  *      to classify a column, not just a single field. 
  */
 
-char classify_type(char32_t *field, char32_t decimal, char32_t sci, char32_t imaginary_unit,
-                   int64_t *i, uint64_t *u,
-                   char prev_type)
+char
+classify_type(char32_t *field,
+        char32_t decimal, char32_t sci, char32_t imaginary_unit,
+        int64_t *i, uint64_t *u, char prev_type)
 {
     int error = 0;
     int success;
@@ -130,7 +131,8 @@ char classify_type(char32_t *field, char32_t decimal, char32_t sci, char32_t ima
  *
  */
 
-char type_for_integer_range(int64_t imin, uint64_t umax)
+char
+type_for_integer_range(int64_t imin, uint64_t umax)
 {
     char type;
 

--- a/src/type_inference.h
+++ b/src/type_inference.h
@@ -3,9 +3,12 @@
 
 #include "typedefs.h"
 
-char classify_type(char32_t *field, char32_t decimal, char32_t sci, char32_t imaginary_unit,
-                   int64_t *i, uint64_t *u,
-                   char prev_type);
-char type_for_integer_range(int64_t imin, uint64_t umax);
+char
+classify_type(char32_t *field,
+        char32_t decimal, char32_t sci, char32_t imaginary_unit,
+        int64_t *i, uint64_t *u, char prev_type);
+
+char
+type_for_integer_range(int64_t imin, uint64_t umax);
 
 #endif


### PR DESCRIPTION
I prefer this style, it also makes finding function names easier.
The other changes, are "seberg" style maybe, and I don't care much.
(this is just because if I don't do it, I am tempted to change it
when close to the code anyway.)