### PR TITLE
BUG: Closes file by removing `stream_file_from_filename`

### DIFF
--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -360,8 +360,24 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
         sizes_ptr = PyArray_DATA(sizes);
     }
 
-    stream *s = stream_file_from_filename(filename, buffer_size);
+    /*
+     * TODO: If we keep this logic around, we should probably replace it
+     *       with the logic used in NumPy's `fromfile` function.
+     *       But, we have to figure out how to handle encoding correctly.
+     *       It may make more sense to assume that we can do this "in Python"
+     *       so long, we use the `read` or `read1` method of the file-like
+     *       object in big chunks (rather than by-line streaming, which we
+     *       have to support, though).
+     */
+    FILE *fp = fopen(filename, "rb");
+    if (fp == NULL) {
+        PyErr_Format(PyExc_RuntimeError, "Unable to open '%s'", filename);
+        return NULL;
+    }
+
+    stream *s = stream_file(fp, buffer_size);
     if (s == NULL) {
+        fclose(fp);
         PyErr_Format(PyExc_RuntimeError, "Unable to open '%s'", filename);
         return NULL;
     }
@@ -371,6 +387,7 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
                                 dtype, num_dtype_fields, codes_ptr, sizes_ptr);
 
     stream_close(s, RESTORE_NOT);
+    fclose(fp);
     return arr;
 }
 

--- a/src/stream_file.c
+++ b/src/stream_file.c
@@ -348,16 +348,3 @@ stream_file(FILE *f, int buffer_size)
     return strm;
 }
 
-
-stream *
-stream_file_from_filename(char *filename, int buffer_size)
-{
-    FILE *fp;
-
-    fp = fopen(filename, "rb");
-    if (fp == NULL) {
-        return NULL;
-    }
-
-    return stream_file(fp, buffer_size);    
-}

--- a/src/stream_file.h
+++ b/src/stream_file.h
@@ -6,7 +6,4 @@
 stream *
 stream_file(FILE *f, int buffer_size);
 
-stream *
-stream_file_from_filename(char *filename, int buffer_size);
-
 #endif


### PR DESCRIPTION
I am not sure this is ideal, but I think the proper solution needs
to rearrange things a bit more in any case.\

---

I tried a `%timeit` on an actual file, and the program ran out of file descriptors or so :) (It could not open more), confused IPython a lot ;).