### PR TITLE
Handle encoding in python layer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
         compat-test-arg: ["numpy.lib.tests.test_io::TestLoadTxt",
                           "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"]
-        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_universal_newline,test_binary_load"]
+        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_binary_load"]
 
     steps:
     - uses: actions/checkout@v2

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -200,7 +200,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                           codes=codes, sizes=sizes,
                                           encoding=encoding)
         else:
-            f = np.lib._datasource.open(fname, 'rt', encoding=encoding)
+            f = np.lib._datasource.open(file, 'rt', encoding=encoding)
             try:
                 enc = encoding.encode('ascii') if encoding is not None else None
                 arr = _readtext_from_file_object(f, delimiter=delimiter,

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -187,34 +187,21 @@ def read(file, *, delimiter=',', comment='#', quote='"',
     # XXX Not everything is handled correctly at the moment.
     #     A Path could contain a .gz file, for example...
     if isinstance(file, str):
-        fname, ext = os.path.splitext(file)
-        if ext not in ['.bz2', '.gz', '.xz', '.lzma'] and encoding is None:
-            arr = _readtext_from_filename(file, delimiter=delimiter,
-                                          comment=comment, quote=quote,
-                                          decimal=decimal, sci=sci,
-                                          imaginary_unit=imaginary_unit,
-                                          usecols=usecols, skiprows=skiprows,
-                                          max_rows=max_rows,
-                                          converters=converters,
-                                          dtype=dtype,
-                                          codes=codes, sizes=sizes,
-                                          encoding=encoding)
-        else:
-            f = np.lib._datasource.open(file, 'rt', encoding=encoding)
-            try:
-                enc = encoding.encode('ascii') if encoding is not None else None
-                arr = _readtext_from_file_object(f, delimiter=delimiter,
-                                                 comment=comment, quote=quote,
-                                                 decimal=decimal, sci=sci,
-                                                 imaginary_unit=imaginary_unit,
-                                                 usecols=usecols,
-                                                 skiprows=skiprows,
-                                                 max_rows=max_rows,
-                                                 converters=converters,
-                                                 dtype=dtype, codes=codes,
-                                                 sizes=sizes, encoding=enc)
-            finally:
-                f.close()
+        f = np.lib._datasource.open(file, 'rt', encoding=encoding)
+        try:
+            enc = encoding.encode('ascii') if encoding is not None else None
+            arr = _readtext_from_file_object(f, delimiter=delimiter,
+                                             comment=comment, quote=quote,
+                                             decimal=decimal, sci=sci,
+                                             imaginary_unit=imaginary_unit,
+                                             usecols=usecols,
+                                             skiprows=skiprows,
+                                             max_rows=max_rows,
+                                             converters=converters,
+                                             dtype=dtype, codes=codes,
+                                             sizes=sizes, encoding=enc)
+        finally:
+            f.close()
     elif isinstance(file, Path):
         with open(file, encoding=encoding) as f:
             enc = encoding.encode('ascii') if encoding is not None else None


### PR DESCRIPTION
Replaces the one instance of `_readtext_from_filename` by instead using `np.lib._datasource.open` to handle the file opening and passing in the result to `_readtext_from_file_object` instead. This has the immediate benefit of fixing the `test_universal_newline` compatibility test, but more generally I think it simplifies the handling of encoding and e.g. compressed files.

I think this is also related to #9. I'm not sure yet, but it may be possible to remove the low-level `filename` utilities (e.g. `stream_from_filename, `_readtext_from_filename` from `npreadtext` entirely. Assuming there are no severe performance penalties, I think this may be preferable as it will make compatibility easier not only with `np.loadtxt` but with Python file handling in general, and can help avoid thorny issues of using low-level file objects, e.g. numpy/numpy#7713, numpy/numpy/#18760