### PR TITLE
BUG: Fix comment ternary operator

### DIFF
--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -331,7 +331,7 @@ _readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
 
     pc.delimiter = *delimiter;
     pc.comment[0] = comment[0];
-    pc.comment[1] = 0 ? (comment[0] == 0) : comment[1];
+    pc.comment[1] = comment[0] == '\0' ? '\0' : comment[1];
     pc.quote = *quote;
     pc.decimal = *decimal;
     pc.sci = *sci;
@@ -418,7 +418,7 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
 
     pc.delimiter = *delimiter;
     pc.comment[0] = comment[0];
-    pc.comment[1] = 0 ? (comment[0] == 0) : comment[1];
+    pc.comment[1] = comment[0] == '\0' ? '\0' : comment[1];
     pc.quote = *quote;
     pc.decimal = *decimal;
     pc.sci = *sci;


### PR DESCRIPTION
Just because my static analyzer keeps bugging me about it really.

If you want to add a test for this: The broken path would be passing
in an empty comment, because it would read a byte too many.

There are more issues here: These are all `char` and not unicode
as they should be...  Apparently, there are probably no tests that
use unicode separators, even though the code should handle them just
fine.