### PR TITLE
MAINT: Fix some compiler warnings (or add comments on hard to fix)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,9 @@ jobs:
     strategy:
       # max-parallel: 4
       matrix:
-        os: [ubuntu]  # Add macos and windows
+        os: [ubuntu, macos]  # Add windows
         python-version: [3.7, 3.8, 3.9]
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
-        compat-test-arg: ["numpy.lib.tests.test_io::TestLoadTxt",
-                          "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"]
         compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_binary_load"]
 
     steps:
@@ -40,7 +38,14 @@ jobs:
 
     - name: loadtxt-compat-regression
       run: |
-        python compat/check_loadtxt_compat.py -v 3 -t ${{ matrix.compat-test-arg }} --ignore ${{ matrix.compat-test-ignore }}
+        python compat/check_loadtxt_compat.py -v 3 -t \
+        numpy.lib.tests.test_io::TestLoadTxt \
+        --ignore ${{ matrix.compat-test-ignore }}
+
+    - name: loadtxt-subarrays-regression
+      run: |
+        python compat/check_loadtxt_compat.py -v 3 -t \
+        "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"
 
     - name: Run C tests
       run: |

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -119,7 +119,6 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
     npy_intp nrows;
     int num_fields;
     field_type *ft = NULL;
-    size_t rowsize;
 
     bool homogeneous;
     npy_intp shape[2];
@@ -157,7 +156,6 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
     }
 
     homogeneous = field_types_is_homogeneous(num_fields, ft);
-    rowsize = field_types_total_size(num_fields, ft);
 
     if (usecols == Py_None) {
         ncols = num_fields;
@@ -182,8 +180,7 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
         char *dtypestr = field_types_build_str(ncols, cols, homogeneous, ft);
         if (dtypestr == NULL) {
             free(ft);
-            PyErr_SetString(PyExc_MemoryError, "out of memory");
-            return NULL;
+            return PyErr_NoMemory();
         }
 
         PyObject *dtstr = PyUnicode_FromString(dtypestr);

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -142,6 +142,10 @@ field_types_build_str(
     // Fill in the string
     int p = 0;
     for (int j = 0; j < num_cols; ++j) {
+        /*
+         * TODO: k is unused, the dtype-inferred path with usecols must
+         *       be broken.
+         */
         int k;
         if (cols == NULL) {
             // No indirection via cols.

--- a/src/rows.c
+++ b/src/rows.c
@@ -15,6 +15,7 @@
 #include "stream.h"
 #include "tokenize.h"
 #include "sizes.h"
+#include "char32utils.h"
 #include "conversions.h"
 #include "field_types.h"
 #include "rows.h"
@@ -81,7 +82,7 @@ max_token_len(
         char32_t **tokens, int num_tokens, int32_t *usecols, int num_usecols)
 {
     size_t maxlen = 0;
-    for (size_t i = 0; i < num_tokens; ++i) {
+    for (int i = 0; i < num_tokens; ++i) {
         size_t j;
         if (usecols == NULL) {
             j = i;
@@ -107,7 +108,7 @@ max_token_len_with_converters(
     size_t maxlen = 0;
     size_t m;
 
-    for (size_t i = 0; i < num_tokens; ++i) {
+    for (int i = 0; i < num_tokens; ++i) {
         size_t j;
         if (usecols == NULL) {
             j = i;
@@ -156,17 +157,17 @@ create_conv_funcs(
         int current_num_fields, read_error_type *read_error)
 {
     PyObject **conv_funcs = NULL;
-    size_t j, k;
 
     conv_funcs = calloc(num_usecols, sizeof(PyObject *));
     if (conv_funcs == NULL) {
         read_error->error_type = ERROR_OUT_OF_MEMORY;
         return NULL;
     }
-    for (j = 0; j < num_usecols; ++j) {
+    for (int j = 0; j < num_usecols; ++j) {
         PyObject *key;
         PyObject *func;
         // k is the column index of the field in the file.
+        size_t k;
         if (usecols == NULL) {
             k = j;
         }
@@ -428,7 +429,6 @@ read_rows(stream *s,
         }
 
         for (j = 0; j < num_usecols; ++j) {
-            int error = ERROR_OK;
             // f is the index into the field_types array.  If there is only
             // one field type, it applies to all fields found in the file.
             int f = (num_field_types == 1) ? 0 : j;
@@ -453,7 +453,7 @@ read_rows(stream *s,
                 }
             }
 
-            read_error->error_type = 0;
+            read_error->error_type = ERROR_OK;
             read_error->line_number = stream_linenumber(s) - 1;
             read_error->field_number = k;
             read_error->char_position = -1; // FIXME

--- a/src/stream.h
+++ b/src/stream.h
@@ -25,7 +25,7 @@ typedef struct _stream {
     int (*stream_seek)(void *sdata, long int pos);
     // Note that the first argument to stream_close is the stream pointer
     // itself, not the stream_data pointer.
-    int (*stream_close)(void *strm, int);
+    int (*stream_close)(struct _stream *strm, int);
 } stream;
 
 


### PR DESCRIPTION
Mostly a few small compiler warnings fixes.  There are still some left, mainly about comparing signed and unsigned ints (for things like num-rows).  I also have a `use_blocks` uninitialized warnings in `rows.c` (and one more), those seems probably spurious.