### PR TITLE
ENH: Rework numpy dtypes into everything

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu, macos]  # Add windows
         python-version: [3.7, 3.8, 3.9]
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
-        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_dtype_with_object,test_from_float_hex,test_binary_load"]
+        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_comments_multiple,test_str_dtype,test_from_float_hex,test_binary_load"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,12 +47,6 @@ jobs:
         python compat/check_loadtxt_compat.py -v 3 -t \
         "numpy.lib.tests.test_regression::TestRegression::test_loadtxt_fields_subarrays"
 
-    - name: Run C tests
-      run: |
-        cd src/ctests
-        bash build_runtest.sh
-        ./runtests
-
   loadtxt-full-compat:
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: true

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -169,8 +169,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
     # creates `codes` and `sizes` using Python than C.
     if dtype is not None:
         dtypes = np.lib._iotools.flatten_dtype(dtype, flatten_base=True)
-        if (len(dtypes) > 1 and usecols is not None and
-                len(codes) != len(usecols)):
+        if (len(dtypes) != 1 and usecols is not None and
+                len(dtypes) != len(usecols)):
             raise ValueError(f"length of usecols ({len(usecols)}) and "
                              f"number of fields in dtype ({len(codes)}) "
                              "do not match.")

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -7,8 +7,7 @@ import operator
 import numpy as np
 from ._filegen import FileGen
 from . import _flatten_dtype
-from ._readtextmodule import (_readtext_from_filename,
-                              _readtext_from_file_object)
+from ._readtextmodule import _readtext_from_file_object
 
 
 def _check_nonneg_int(value, name="argument"):
@@ -169,19 +168,16 @@ def read(file, *, delimiter=',', comment='#', quote='"',
     # information.  This is because it is easier to write the code that
     # creates `codes` and `sizes` using Python than C.
     if dtype is not None:
-        codes, sizes = _flatten_dtype.flatten_dtype2(dtype)
-        if (len(codes) > 1 and usecols is not None and
+        dtypes = np.lib._iotools.flatten_dtype(dtype, flatten_base=True)
+        if (len(dtypes) > 1 and usecols is not None and
                 len(codes) != len(usecols)):
             raise ValueError(f"length of usecols ({len(usecols)}) and "
                              f"number of fields in dtype ({len(codes)}) "
                              "do not match.")
-        if len(codes) == 1 and usecols is not None:
-            codes = np.repeat(codes, len(usecols))
-            sizes = np.repeat(sizes, len(usecols))
-            assert sizes.dtype == np.int32
+        if len(dtypes) == 1 and usecols is not None:
+            dtypes *= len(usecols)
     else:
-        codes = None
-        sizes = None
+        dtypes = None
 
     # XXX Reorganize these nested ifs...
     # XXX Not everything is handled correctly at the moment.
@@ -198,8 +194,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                              skiprows=skiprows,
                                              max_rows=max_rows,
                                              converters=converters,
-                                             dtype=dtype, codes=codes,
-                                             sizes=sizes, encoding=enc)
+                                             dtype=dtype, dtypes=dtypes,
+                                             encoding=enc)
         finally:
             f.close()
     elif isinstance(file, Path):
@@ -213,7 +209,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                              skiprows=skiprows,
                                              max_rows=max_rows,
                                              converters=converters,
-                                             dtype=dtype,
+                                             dtype=dtype, dtypes=dtypes,
                                              codes=codes, sizes=sizes,
                                              encoding=enc)
     elif isinstance(file, types.GeneratorType):
@@ -231,8 +227,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                          skiprows=skiprows,
                                          max_rows=max_rows,
                                          converters=converters,
-                                         dtype=dtype,
-                                         codes=codes, sizes=sizes,
+                                         dtype=dtype, dtypes=dtypes,
                                          encoding=enc)
     else:
         # Assume file is a file object.
@@ -244,7 +239,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                                          usecols=usecols, skiprows=skiprows,
                                          max_rows=max_rows,
                                          converters=converters,
-                                         dtype=dtype, codes=codes, sizes=sizes,
+                                         dtype=dtype, dtypes=dtypes,
                                          encoding=enc)
 
     if ndmin is not None:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open('README.rst', 'r') as f:
 
 
 def configuration(parent_package='', top_path=None):
+    import numpy
     from numpy.distutils.misc_util import Configuration
 
     config = Configuration(None, parent_package, top_path)
@@ -37,9 +38,11 @@ def configuration(parent_package='', top_path=None):
               'conversions.c', 'str_to.c', 'str_to_int.c', 'str_to_double.c',
               'pow10table.c',
               'stream_file.c', 'stream_python_file_by_line.c', 'blocks.c',
-              'char32utils.c', 'field_types.c', 'dtoa_modified.c']
-    config.add_extension('npreadtext._readtextmodule',
-                         sources=[path.join('src', t) for t in cfiles])
+              'char32utils.c', 'field_types.c', 'dtoa_modified.c',]
+    config.add_extension(
+            'npreadtext._readtextmodule',
+            sources=[path.join('src', t) for t in cfiles],
+            include_dirs=[numpy.get_include()],)
     return config
 
 

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -8,7 +8,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
-#include <numpy/arrayobject.h>
+#include "numpy/arrayobject.h"
 
 #include "parser_config.h"
 #include "stream_file.h"

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -7,6 +7,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
 #include <numpy/arrayobject.h>
 
 #include "parser_config.h"
@@ -111,9 +112,11 @@ static PyObject *
 _readtext_from_stream(stream *s, char *filename, parser_config *pc,
                       PyObject *usecols, int skiprows, int max_rows,
                       PyObject *converters,
-                      PyObject *dtype, int num_dtype_fields, char *codes, int32_t *sizes)
+                      PyObject *dtype, PyArray_Descr **dtypes,
+                      int num_dtype_fields)
 {
     PyObject *arr = NULL;
+    PyArray_Descr *out_dtype = NULL;
     int32_t *cols;
     int ncols;
     npy_intp nrows;
@@ -141,22 +144,44 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
             // an array with shape (0, 0) and data type float64.
             npy_intp dims[2] = {0, 0};
             arr = PyArray_SimpleNew(2, dims, NPY_FLOAT64);
-            return arr;
+            goto finish;
+        }
+        homogeneous = field_types_is_homogeneous(num_fields, ft);
+        if (field_types_init_descriptors(num_fields, ft) < 0) {
+            goto finish;
+        }
+        if (homogeneous) {
+            out_dtype = ft[0].descr;
+            Py_INCREF(out_dtype);
+        }
+        else {
+            out_dtype = field_types_to_descr(num_fields, ft);
+            if (out_dtype == NULL) {
+                goto finish;
+            }
         }
     }
     else {
+        /*
+         * If dtypes[0] is dtype the input was not structured and the result
+         * is considered "homogeneous" and we have to discover the number of
+         * columns/
+         */
+        out_dtype = (PyArray_Descr *)dtype;
+        Py_INCREF(out_dtype);
+
+        /* TODO: Ridiculous, should just pass it in (or reuse num_fields) */
+        homogeneous = num_dtype_fields == 1 && (out_dtype == dtypes[0]);
+
         // A dtype was given.
         num_fields = num_dtype_fields;
-        ft = field_types_create(num_fields, codes, sizes);
+        ft = field_types_create(num_fields, dtypes);
         if (ft == NULL) {
             PyErr_Format(PyExc_MemoryError, "out of memory");
             return NULL;
         }
         nrows = max_rows;
     }
-
-    homogeneous = field_types_is_homogeneous(num_fields, ft);
-
     if (usecols == Py_None) {
         ncols = num_fields;
         cols = NULL;
@@ -176,26 +201,8 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
         int num_cols;
         int ndim = homogeneous ? 2 : 1;
 
-        // Build the dtype from the ft array of field types.
-        char *dtypestr = field_types_build_str(ncols, cols, homogeneous, ft);
-        if (dtypestr == NULL) {
-            free(ft);
-            return PyErr_NoMemory();
-        }
-
-        PyObject *dtstr = PyUnicode_FromString(dtypestr);
-        free(dtypestr);
-        if (!dtstr) {
-            free(ft);
-            return NULL;
-        }
-        PyArray_Descr *dtype1;
-        if (!PyArray_DescrConverter(dtstr, &dtype1)) {
-            free(ft);
-            return NULL;
-        }
-
-        arr = PyArray_SimpleNewFromDescr(ndim, shape, dtype1);
+        Py_INCREF(out_dtype);
+        arr = PyArray_SimpleNewFromDescr(ndim, shape, out_dtype);
         if (!arr) {
             free(ft);
             return NULL;
@@ -206,7 +213,7 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
                                  cols, ncols, skiprows,
                                  converters,
                                  PyArray_DATA(arr),
-                                 &num_cols, &read_error);
+                                 &num_cols, homogeneous, &read_error);
         if (read_error.error_type != 0) {
             free(ft);
             raise_read_exception(&read_error);
@@ -225,7 +232,7 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
                                    (ft[0].typecode == 'U')));
         void *result = read_rows(s, &num_rows, num_fields, ft, pc,
                                  cols, ncols, skiprows, converters,
-                                 NULL, &num_cols, &read_error);
+                                 NULL, &num_cols, homogeneous, &read_error);
         if (read_error.error_type != 0) {
             free(ft);
             raise_read_exception(&read_error);
@@ -233,7 +240,7 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
         }
 
         shape[0] = num_rows;
-        if (PyDataType_ISSTRING(dtype) || !PyDataType_ISEXTENDED(dtype)) {
+        if (PyDataType_ISSTRING(out_dtype) || !PyDataType_ISEXTENDED(out_dtype)) {
             ndim = 2;
             if (num_rows > 0) {
                 shape[1] = num_cols;
@@ -265,9 +272,9 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
         else {
             // We have to INCREF dtype, because the Python caller owns a
             // reference, and PyArray_NewFromDescr steals a reference to it.
-            Py_INCREF(dtype);
+            Py_INCREF(out_dtype);
             // XXX Fix memory management - `result` was malloc'd.
-            arr = PyArray_NewFromDescr(&PyArray_Type, (PyArray_Descr *) dtype,
+            arr = PyArray_NewFromDescr(&PyArray_Type, out_dtype,
                                        ndim, shape, NULL, result, 0, NULL);
         }
         if (!arr) {
@@ -277,114 +284,12 @@ _readtext_from_stream(stream *s, char *filename, parser_config *pc,
         }
     }
 
-    free(ft);
-
-    return arr;
-}
-
-
-static PyObject *
-_readtext_from_filename(PyObject *self, PyObject *args, PyObject *kwargs)
-{
-    static char *kwlist[] = {"filename", "delimiter", "comment", "quote",
-                             "decimal", "sci", "imaginary_unit",
-                             "usecols", "skiprows",
-                             "max_rows", "converters",
-                             "dtype", "codes", "sizes",
-                             "encoding", NULL};
-    char *filename;
-    char *delimiter = ",";
-    char *comment = "#";
-    char *quote = "\"";
-    char *decimal = ".";
-    char *sci = "E";
-    char *imaginary_unit = "j";
-    int skiprows;
-    int max_rows;
-
-    PyObject *usecols;
-    PyObject *converters;
-
-    PyObject *dtype;
-    PyObject *codes;
-    PyObject *sizes;
-    PyObject *encoding;
-
-    char *codes_ptr = NULL;
-    int32_t *sizes_ptr = NULL;
-
-    parser_config pc;
-    int buffer_size = 1 << 21;
-    PyObject *arr = NULL;
-    int num_dtype_fields;
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|$ssssssOiiOOOOO", kwlist,
-                                     &filename, &delimiter, &comment, &quote,
-                                     &decimal, &sci, &imaginary_unit, &usecols, &skiprows,
-                                     &max_rows, &converters,
-                                     &dtype, &codes, &sizes, &encoding)) {
-        return NULL;
+  finish:
+    Py_XDECREF(out_dtype);
+    if (ft != NULL) {
+        field_types_clear(num_fields, ft);
+        free(ft);
     }
-
-    pc.delimiter = *delimiter;
-    pc.comment[0] = comment[0];
-    pc.comment[1] = comment[0] == '\0' ? '\0' : comment[1];
-    pc.quote = *quote;
-    pc.decimal = *decimal;
-    pc.sci = *sci;
-    pc.imaginary_unit = *imaginary_unit;
-    pc.allow_float_for_int = true;
-    pc.allow_embedded_newline = true;
-    pc.ignore_leading_spaces = false;
-    pc.ignore_trailing_spaces = false;
-    pc.ignore_blank_lines = true;
-    pc.strict_num_fields = false;
-
-    if (dtype == Py_None) {
-        num_dtype_fields = -1;
-        codes_ptr = NULL;
-        sizes_ptr = NULL;
-    }
-    else {
-        // If `dtype` is not None, then `codes` must be a contiguous 1-d numpy
-        // array with dtype 'S1' (i.e. an array of characters), and `sizes`
-        // must be a contiguous 1-d numpy array with dtype int32 that has the
-        // same length as `codes`.  This code assumes this is true and does not
-        // validate the arguments--it is expected that the calling code will
-        // do so.
-        num_dtype_fields = PyArray_SIZE(codes);
-        codes_ptr = PyArray_DATA(codes);
-        sizes_ptr = PyArray_DATA(sizes);
-    }
-
-    /*
-     * TODO: If we keep this logic around, we should probably replace it
-     *       with the logic used in NumPy's `fromfile` function.
-     *       But, we have to figure out how to handle encoding correctly.
-     *       It may make more sense to assume that we can do this "in Python"
-     *       so long, we use the `read` or `read1` method of the file-like
-     *       object in big chunks (rather than by-line streaming, which we
-     *       have to support, though).
-     */
-    FILE *fp = fopen(filename, "rb");
-    if (fp == NULL) {
-        PyErr_Format(PyExc_RuntimeError, "Unable to open '%s'", filename);
-        return NULL;
-    }
-
-    stream *s = stream_file(fp, buffer_size);
-    if (s == NULL) {
-        fclose(fp);
-        PyErr_Format(PyExc_RuntimeError, "Unable to open '%s'", filename);
-        return NULL;
-    }
-
-    arr = _readtext_from_stream(s, filename, &pc, usecols, skiprows, max_rows,
-                                converters,
-                                dtype, num_dtype_fields, codes_ptr, sizes_ptr);
-
-    stream_close(s, RESTORE_NOT);
-    fclose(fp);
     return arr;
 }
 
@@ -396,7 +301,7 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
                              "decimal", "sci", "imaginary_unit",
                              "usecols", "skiprows",
                              "max_rows", "converters",
-                             "dtype", "codes", "sizes",
+                             "dtype", "dtypes",
                              "encoding", NULL};
     PyObject *file;
     char *delimiter = ",";
@@ -411,22 +316,20 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *converters;
 
     PyObject *dtype;
-    PyObject *codes;
-    PyObject *sizes;
+    PyObject *dtypes_obj = NULL;
     PyObject *encoding;
 
-    char *codes_ptr = NULL;
-    int32_t *sizes_ptr = NULL;
+    PyArray_Descr **dtypes = NULL;
 
     parser_config pc;
     PyObject *arr = NULL;
     int num_dtype_fields;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$ssssssOiiOOOOO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$ssssssOiiOOOO", kwlist,
                                      &file, &delimiter, &comment, &quote,
                                      &decimal, &sci, &imaginary_unit, &usecols, &skiprows,
                                      &max_rows, &converters,
-                                     &dtype, &codes, &sizes, &encoding)) {
+                                     &dtype, &dtypes_obj, &encoding)) {
         return NULL;
     }
 
@@ -444,32 +347,33 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     pc.ignore_blank_lines = true;
     pc.strict_num_fields = false;
 
-    if (dtype == Py_None) {
+    /*
+     * TODO: This needs some hefty input validation!
+     */
+    if (dtypes_obj == Py_None) {
+        assert(dtype == Py_None);
         num_dtype_fields = -1;
-        codes_ptr = NULL;
-        sizes_ptr = NULL;
     }
     else {
-        // If `dtype` is not None, then `codes` must be a contiguous 1-d numpy
-        // array with dtype 'S1' (i.e. an array of characters), and `sizes`
-        // must be a contiguous 1-d numpy array with dtype int32 that has the
-        // same length as `codes`.  This code assumes this is true and does not
-        // validate the arguments--it is expected that the calling code will
-        // do so.
-        num_dtype_fields = PyArray_SIZE(codes);
-        codes_ptr = PyArray_DATA(codes);
-        sizes_ptr = PyArray_DATA(sizes);
+        dtypes_obj = PySequence_Fast(dtypes_obj, "dtypes not a sequence :(");
+        if (dtypes_obj == NULL) {
+            return NULL;
+        }
+        num_dtype_fields = PySequence_Fast_GET_SIZE(dtypes_obj);
+        dtypes = (PyArray_Descr **)PySequence_Fast_ITEMS(dtypes_obj);
     }
 
     stream *s = stream_python_file_by_line(file, encoding);
     if (s == NULL) {
         PyErr_Format(PyExc_RuntimeError, "Unable to access the file.");
+        Py_DECREF(dtypes_obj);
         return NULL;
     }
 
     arr = _readtext_from_stream(s, NULL, &pc, usecols, skiprows, max_rows,
                                 converters,
-                                dtype, num_dtype_fields, codes_ptr, sizes_ptr);
+                                dtype, dtypes, num_dtype_fields);
+    Py_DECREF(dtypes_obj);
     stream_close(s, RESTORE_NOT);
     return arr;
 }
@@ -481,8 +385,6 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyMethodDef module_methods[] = {
     {"_readtext_from_file_object", (PyCFunction) _readtext_from_file_object,
-         METH_VARARGS | METH_KEYWORDS, "testing"},
-    {"_readtext_from_filename", (PyCFunction) _readtext_from_filename,
          METH_VARARGS | METH_KEYWORDS, "testing"},
     {0} // sentinel
 };

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -69,9 +69,9 @@ raise_read_exception(read_error_type *read_error)
     }
     else if (read_error->error_type == ERROR_BAD_FIELD) {
         PyErr_Format(PyExc_RuntimeError,
-                     "line %d, field %d: bad %s value",
+                     "line %d, field %d: bad %S value",
                      read_error->line_number, read_error->field_number + 1,
-                     typecode_to_str(read_error->typecode));
+                     read_error->descr);
     }
     else if (read_error->error_type == ERROR_CHANGED_NUMBER_OF_FIELDS) {
         PyObject *exc = LOADTXT_COMPATIBILITY ? PyExc_ValueError : PyExc_RuntimeError;

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -92,7 +92,7 @@ blocks_destroy(blocks_data *b)
 //
 
 char *
-blocks_get_row_ptr(blocks_data *b, size_t k)
+blocks_get_row_ptr(blocks_data *b, size_t k, bool needs_init)
 {
     int rows_per_block = b->rows_per_block;
     int block_table_length = b->block_table_length;
@@ -129,7 +129,12 @@ blocks_get_row_ptr(blocks_data *b, size_t k)
     if (b->block_table[block_number] == NULL) {
         // Haven't allocated this block yet...
         int block_size = b->row_size * rows_per_block;
-        b->block_table[block_number] = malloc(block_size);
+        if (!needs_init) {
+            b->block_table[block_number] = malloc(block_size);
+        }
+        else {
+            b->block_table[block_number] = calloc(block_size, 1);
+        }
         if (b->block_table[block_number] == NULL) {
             return NULL;
         }
@@ -227,7 +232,7 @@ int main(int argc, char *argv[])
     }
 
     for (size_t k = 0; k < num_rows; ++k) {
-        char *ptr = blocks_get_row_ptr(b, k);
+        char *ptr = blocks_get_row_ptr(b, k, false);
         if (ptr == NULL) {
             fprintf(stderr, "blocks_get_row_ptr(b, %zu) returned NULL\n", k);
             exit(-1);

--- a/src/blocks.h
+++ b/src/blocks.h
@@ -1,6 +1,8 @@
 #ifndef _BLOCKS_H_
 #define _BLOCKS_H_
 
+#include <stdbool.h>
+
 
 typedef struct _blocks_data
 {
@@ -18,7 +20,7 @@ void
 blocks_destroy(blocks_data *b);
 
 char *
-blocks_get_row_ptr(blocks_data *b, size_t k);
+blocks_get_row_ptr(blocks_data *b, size_t k, bool needs_init);
 
 int
 blocks_uniform_resize(blocks_data *b, size_t num_fields, size_t new_itemsize);

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -10,9 +10,21 @@
 #include <stdbool.h>
 #include "field_types.h"
 
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
+#include <numpy/arrayobject.h>
+
+
+void
+field_types_clear(int num_field_types, field_type *ft) {
+    for (int i = 0; i < num_field_types; i++) {
+        Py_XDECREF(ft[i].descr);
+        ft[i].descr = NULL;
+    }
+}
 
 field_type *
-field_types_create(int num_field_types, const char *codes, const int32_t *sizes)
+field_types_create(int num_field_types, PyArray_Descr *dtypes[])
 {
     field_type *ft;
 
@@ -21,8 +33,32 @@ field_types_create(int num_field_types, const char *codes, const int32_t *sizes)
         return NULL;
     }
     for (int i = 0; i < num_field_types; ++i) {
-        ft[i].typecode = codes[i];
-        ft[i].itemsize = sizes[i];
+        PyArray_Descr *descr = dtypes[i];
+        if (PyDataType_ISSIGNED(descr)) {
+            ft[i].typecode = 'i';
+        }
+        else if (PyDataType_ISUNSIGNED(descr)) {
+            ft[i].typecode = 'u';
+        }
+        else if (PyDataType_ISFLOAT(descr) && descr->elsize <= 8) {
+            ft[i].typecode = 'f';
+        }
+        else if (PyDataType_ISCOMPLEX(descr) && descr->elsize <= 16) {
+            ft[i].typecode = 'c';
+        }
+        else if (descr->type_num == NPY_STRING) {
+            ft[i].typecode = 'S';
+        }
+        else if (descr->type_num == NPY_UNICODE) {
+            ft[i].typecode = 'U';
+        }
+        else {
+            ft[i].typecode = 'x';
+        }
+        ft[i].itemsize = descr->elsize;
+        Py_INCREF(descr);
+        ft[i].descr = descr;
+        ft[i].swap = !PyArray_ISNBO(descr->byteorder);
     }
     return ft;
 }
@@ -31,8 +67,8 @@ void
 field_types_fprintf(FILE *out, int num_field_types, const field_type *ft)
 {
     for (int i = 0; i < num_field_types; ++i) {
-        fprintf(out, "ft[%d].typecode = %c, .itemsize = %d\n",
-                     i, ft[i].typecode, ft[i].itemsize);
+        fprintf(out, "ft[%d].typecode = %c, .itemsize = %lu\n",
+                     i, ft[i].typecode, (unsigned long)ft[i].itemsize);
     }
 }
 
@@ -84,6 +120,8 @@ field_types_grow(int new_num_field_types, int num_field_types, field_type **ft)
     for (int k = num_field_types; k < new_num_field_types; ++k) {
         new_ft[k].typecode = '*';
         new_ft[k].itemsize = 0;
+        new_ft[k].descr = NULL;
+        new_ft[k].swap = false;  /* normally never swap */
     }
     *ft = new_ft;
 
@@ -91,7 +129,9 @@ field_types_grow(int new_num_field_types, int num_field_types, field_type **ft)
 }
 
 
-char *typecode_to_str(char typecode)
+/* TODO: This function is only used for error reporting, but nonsense now */
+char *
+typecode_to_str(char typecode)
 {
     char *typ;
 
@@ -117,73 +157,123 @@ char *typecode_to_str(char typecode)
 }
 
 
-//
-// Build a comma separated string representation of the dtype.
-// If cols == NULL, it is not used.  Otherwise it is an array
-// of length num_cols that gives the index into ft to use.
-//
-char *
-field_types_build_str(
-        int num_cols, const int32_t *cols, bool homogeneous,
-        const field_type *ft)
+/*
+ * Convert the discovered dtypes to descriptors.  This function cleans up
+ * after itself on error.
+ *
+ * TODO: We are assuming here sane systems with 1, 2, 4, and 8 byte sized
+ *       integers.  But NumPy relies more on the C levels.
+ */
+int
+field_types_init_descriptors(int num_field_types, field_type *ft)
 {
-    char *dtypestr;
-    size_t len;
+    for (int i = 0; i < num_field_types; i++) {
+        int typenum = -1;
 
-    // Precompute the length of the string.
-    // len = ...
-    len = num_cols * 8;   // FIXME: crude estimate
-    dtypestr = malloc(len);
+        /* Strings have adaptable length, so handle it specifically. */
+        if (ft[i].typecode == 'S' || ft[i].typecode == 'U') {
+            typenum = ft[i].typecode == 'S' ? NPY_STRING : NPY_UNICODE;
+            ft[i].descr = PyArray_DescrNewFromType(typenum);
+            if (ft[i].descr == NULL) {
+                field_types_clear(num_field_types, ft);
+                return -1;
+            }
+            ft[i].descr->elsize = ft[i].itemsize;
+            continue;
+        }
 
-    if (dtypestr == NULL) {
-        return NULL;
-    }
-
-    // Fill in the string
-    int p = 0;
-    for (int j = 0; j < num_cols; ++j) {
-        /*
-         * TODO: k is unused, the dtype-inferred path with usecols must
-         *       be broken.
-         */
-        int k;
-        if (cols == NULL) {
-            // No indirection via cols.
-            k = j;
+        if (ft[i].typecode == 'i') {
+            size_t itemsize = ft[i].itemsize;
+            switch (itemsize) {
+                case 1:
+                    typenum = NPY_INT8;
+                    break;
+                case 2:
+                    typenum = NPY_INT16;
+                    break;
+                case 4:
+                    typenum = NPY_INT32;
+                    break;
+                case 8:
+                    typenum = NPY_INT64;
+                    break;
+            }
+        }
+        else if (ft[i].typecode == 'u') {
+            size_t itemsize = ft[i].itemsize;
+            switch (itemsize) {
+                case 1:
+                    typenum = NPY_UINT8;
+                    break;
+                case 2:
+                    typenum = NPY_UINT16;
+                    break;
+                case 4:
+                    typenum = NPY_UINT32;
+                    break;
+                case 8:
+                    typenum = NPY_UINT64;
+                    break;
+            }
+        }
+        else if (ft[i].typecode == 'f') {
+            typenum = NPY_DOUBLE;
+        }
+        else if (ft[i].typecode == 'c') {
+            typenum = NPY_CDOUBLE;
+        }
+        else if (ft[i].typecode == '*') {
+            typenum = NPY_DOUBLE;  /* use the default */
         }
         else {
-            // FIXME Values in usecols have not been validated!!!
-            k = cols[j];
+            /* will error below, but add assert for debugging */
+            assert(0);
         }
-        if (j > 0) {
-            dtypestr[p++] = ',';
-        }
-        if (ft[j].typecode == 'c') {
-            dtypestr[p] = 'F';
-        }
-        else if (ft[j].typecode == 'z') {
-            dtypestr[p] = 'D';
-        }
-        else {
-            dtypestr[p] = ft[j].typecode;
-        }
-        ++p;
-        if (ft[j].typecode == 'S') {
-            int nc = snprintf(dtypestr + p, len - p - 1, "%d", ft[j].itemsize);
-            p += nc;
-        }
-        else if (ft[j].typecode == 'U') {
-            int nc = snprintf(dtypestr + p, len - p - 1, "%d", ft[j].itemsize / 4);
-            p += nc;
-        }
-        if (homogeneous) {
-            break;
+
+        ft[i].descr = PyArray_DescrFromType(typenum);
+        if (ft[i].descr == NULL) {
+            /* can't actually fail, but... */
+            field_types_clear(num_field_types, ft);
+            return -1;
         }
     }
-    dtypestr[p] = '\0';
-    return dtypestr;
+    return 0;
 }
 
+
+PyArray_Descr *
+field_types_to_descr(int num_fields, field_type *ft)
+{
+    PyArray_Descr *result = NULL;
+    PyObject *dtype_list = NULL, *empty_string = NULL;
+
+    empty_string = PyUnicode_FromString("");
+    if (empty_string == NULL) {
+        goto finish;
+    }
+    dtype_list = PyList_New(0);
+    if (dtype_list == NULL) {
+        goto finish;
+    }
+
+    for (int i = 0; i < num_fields; i++) {
+        PyObject *tup = PyTuple_Pack(2, empty_string, ft[i].descr);
+        if (tup == NULL) {
+            goto finish;
+        }
+        int res = PyList_Append(dtype_list, tup);
+        Py_DECREF(tup);
+        if (res < 0) {
+            goto finish;
+        }
+    }
+    PyArray_DescrConverter(dtype_list, &result);
+
+  finish:
+    Py_XDECREF(empty_string);
+    Py_XDECREF(dtype_list);
+    return result;
+}
 
 #ifdef TESTMAIN
 
@@ -196,7 +286,7 @@ show_field_types(int num_fields, field_type *ft)
     printf("homogeneous = %s\n", homogeneous ? "true" : "false");
 
     int32_t total_size = field_types_total_size(num_fields, ft);
-    printf("total_size = %d\n", total_size);
+    printf("total_size = %lu\n", (unsigned long)total_size);
 
     char *dtypestr = field_types_build_str(num_fields, NULL, homogeneous, ft);
     printf("dtypestr = '%s'\n", dtypestr);

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -129,34 +129,6 @@ field_types_grow(int new_num_field_types, int num_field_types, field_type **ft)
 }
 
 
-/* TODO: This function is only used for error reporting, but nonsense now */
-char *
-typecode_to_str(char typecode)
-{
-    char *typ;
-
-    switch (typecode) {
-        case 'b': typ = "int8"; break;
-        case 'B': typ = "uint8"; break;
-        case 'h': typ = "int16"; break;
-        case 'H': typ = "uint16"; break;
-        case 'i': typ = "int32"; break;
-        case 'I': typ = "uint32"; break;
-        case 'q': typ = "int64"; break;
-        case 'Q': typ = "uint64"; break;
-        case 'f': typ = "float32"; break;
-        case 'd': typ = "float64"; break;
-        case 'c': typ = "complex64"; break;
-        case 'z': typ = "complex128"; break;
-        case 'S': typ = "S"; break;
-        case 'U': typ = "U"; break;
-        default:  typ = "unknown";
-    }
-
-    return typ;
-}
-
-
 /*
  * Convert the discovered dtypes to descriptors.  This function cleans up
  * after itself on error.

--- a/src/field_types.h
+++ b/src/field_types.h
@@ -4,39 +4,41 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
+#include <numpy/ndarraytypes.h>
 
 
 typedef struct _field_type {
     // typecode:
-    //   Format characters for data type of a field (mostly compatible with
-    //   the codes in the python struct module):
-    //     b : 8 bit signed char
-    //     B : 8 bit unsigned char
-    //     h : 16 bit signed integer
-    //     H : 16 bit unsigned integer
-    //     i : 32 bit signed integer
-    //     I : 32 bit unsigned integer
-    //     q : 64 bit signed integer
-    //     Q : 64 bit unsigned integer
-    //     f : 32 bit floating point
-    //     d : 64 bit floating point
-    //     c : 32 bit complex (real and imag are each 32 bit) (not implemented)
-    //     z : 64 bit complex (real and imag are each 64 bit) (not implemented)
+    //     * : undefined field type (during auto-discovery)
+    //     i : integer (byte to long long)
+    //     u : unsigned integer (ubyte to unsigned long long)
+    //     f : floating point (or double) -- not float128, as it can't be
+    //         handled by the builtin parser (we ignore it here).
+    //     c : complex (64bit or 128 bit).
     //     S : character string (1 character == 1 byte)
     //     U : Unicode string (32 bit codepoints)
+    //     x : generic dtype.
     char typecode;
+    /* Whether the simple(!) typecode descriptor needs swapping */
+    bool swap;
 
     // itemsize:
     //   Size of field, in bytes.  In theory this would only be
     //   needed for the 'S' or 'U' type codes, but it is expected to be
     //   correctly filled in for all the types.
-    int32_t itemsize;
+    size_t itemsize;
 
+    /* The original NumPy descriptor */
+    PyArray_Descr *descr;
 } field_type;
 
 
+void
+field_types_clear(int num_field_types, field_type *ft);
+
 field_type *
-field_types_create(int num_field_types, const char *codes, const int *sizes);
+field_types_create(int num_field_types, PyArray_Descr *dtypes[]);
 
 void
 field_types_fprintf(FILE *out, int num_field_types, const field_type *ft);
@@ -50,10 +52,11 @@ field_types_total_size(int num_field_types, const field_type *ft);
 int
 field_types_grow(int new_num_field_types, int num_field_types, field_type **ft);
 
-char *
-field_types_build_str(
-        int num_cols, const int32_t *cols, bool homogeneous,
-        const field_type *ft);
+int
+field_types_init_descriptors(int num_field_types, field_type *ft);
+
+PyArray_Descr *
+field_types_to_descr(int num_fields, field_type *ft);
 
 char *
 typecode_to_str(char typecode);

--- a/src/field_types.h
+++ b/src/field_types.h
@@ -5,7 +5,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
-#include <numpy/ndarraytypes.h>
+#define NO_IMPORT_ARRAY
+#include "numpy/ndarraytypes.h"
 
 
 typedef struct _field_type {

--- a/src/field_types.h
+++ b/src/field_types.h
@@ -58,7 +58,4 @@ field_types_init_descriptors(int num_field_types, field_type *ft);
 PyArray_Descr *
 field_types_to_descr(int num_fields, field_type *ft);
 
-char *
-typecode_to_str(char typecode);
-
 #endif

--- a/src/rows.c
+++ b/src/rows.c
@@ -466,7 +466,7 @@ read_rows(stream *s,
             read_error->line_number = stream_linenumber(s) - 1;
             read_error->field_number = k;
             read_error->char_position = -1; // FIXME
-            read_error->typecode = typecode;
+            read_error->descr = field_types[f].descr;
 
             int err = ERROR_OK;
 

--- a/src/rows.c
+++ b/src/rows.c
@@ -32,6 +32,19 @@
 
 #define ALLOW_PARENS true
 
+
+/*
+ * Defines liberated from NumPy's, only used for the PyArray_Pack hack!
+ * TODO: Remove!
+ */
+#if PY_VERSION_HEX < 0x030900a4
+    /* Introduced in https://github.com/python/cpython/commit/d2ec81a8c99796b51fb8c49b77a7fe369863226f */
+    #define Py_SET_TYPE(obj, type) ((Py_TYPE(obj) = (type)), (void)0)
+    /* Introduced in https://github.com/python/cpython/commit/c86a11221df7e37da389f9c6ce6e47ea22dc44ff */
+    #define Py_SET_REFCNT(obj, refcnt) ((Py_REFCNT(obj) = (refcnt)), (void)0)
+#endif
+
+
 //
 // If num_field_types is not 1, actual_num_fields must equal num_field_types.
 //

--- a/src/rows.c
+++ b/src/rows.c
@@ -5,7 +5,7 @@
 #include <Python.h>
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
-#include <numpy/arrayobject.h>
+#include "numpy/arrayobject.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/rows.c
+++ b/src/rows.c
@@ -3,6 +3,9 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
+#include <numpy/arrayobject.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -61,7 +64,7 @@ call_converter_function(PyObject *func, char32_t *token)
         ++tokenlen;
     }
     PyObject *s = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, token, tokenlen);
-    if (s == NULL) {
+    if (s == NULL || func == NULL) {
         // fprintf(stderr, "*** PyUnicode_FromKindAndData failed ***\n");
         return s;
     }
@@ -233,7 +236,7 @@ read_rows(stream *s,
         int *nrows, int num_field_types, field_type *field_types,
         parser_config *pconfig, int32_t *usecols, int num_usecols,
         int skiplines, PyObject *converters, void *data_array,
-        int *num_cols, read_error_type *read_error)
+        int *num_cols, bool homogeneous, read_error_type *read_error)
 {
     char *data_ptr;
     int current_num_fields;
@@ -295,7 +298,7 @@ read_rows(stream *s,
             // We've deferred some of the initialization tasks to here,
             // because we've now read the first line, and we definitively
             // know how many fields (i.e. columns) we will be processing.
-            if (num_field_types > 1) {
+            if (!homogeneous) {
                 actual_num_fields = num_field_types;
             }
             else if (usecols != NULL) {
@@ -327,6 +330,9 @@ read_rows(stream *s,
                 if (conv_funcs == NULL) {
                     return NULL;
                 }
+            }
+            else {
+                conv_funcs = calloc(num_usecols, sizeof(PyObject *));
             }
 
             if (track_string_size) {
@@ -405,6 +411,7 @@ read_rows(stream *s,
                         }
                     }
                     field_types[0].itemsize = new_itemsize;
+                    field_types[0].descr->elsize = new_itemsize;
                 }
             }    
         }
@@ -431,8 +438,9 @@ read_rows(stream *s,
         for (j = 0; j < num_usecols; ++j) {
             // f is the index into the field_types array.  If there is only
             // one field type, it applies to all fields found in the file.
-            int f = (num_field_types == 1) ? 0 : j;
+            int f = homogeneous ? 0 : j;
             char typecode = field_types[f].typecode;
+            size_t itemsize = field_types[f].itemsize;
             PyObject *converted = NULL;
 
             // k is the column index of the field in the file.
@@ -459,270 +467,103 @@ read_rows(stream *s,
             read_error->char_position = -1; // FIXME
             read_error->typecode = typecode;
 
-            if (conv_funcs && conv_funcs[j]) {
-                converted = call_converter_function(conv_funcs[j], result[k]);
-                if (converted == NULL) {
-                    read_error->error_type = ERROR_CONVERTER_FAILED;
+            int err = ERROR_OK;
+
+            if (k >= current_num_fields && (
+                    typecode == 'i' || typecode == 'u')) {
+                /* Memset here for simplicity with integers */
+                memset(data_ptr, '\0', itemsize);
+            }
+            else if (typecode == 'i') {
+                switch (itemsize) {
+                    case 1:
+                        err = to_int8(result[k], pconfig, data_ptr);
+                        break;
+                    case 2:
+                        err = to_int16(result[k], pconfig, data_ptr);
+                        break;
+                    case 4:
+                        err = to_int32(result[k], pconfig, data_ptr);
+                        break;
+                    case 8:
+                        err = to_int64(result[k], pconfig, data_ptr);
+                        break;
+                    default:
+                        assert(0);
+                }
+                if (err) {
+                    read_error->error_type = err;
                     break;
                 }
             }
-
-            // FIXME: There is a lot of repeated code in the following.
-            // This needs to be modularized.
-
-            if (typecode == 'b') {
-                int8_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        long long value = PyLong_AsLongLong(converted);
-                        if (value == -1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (int8_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_int8(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
+            else if (typecode == 'u') {
+                switch (itemsize) {
+                    case 1:
+                        err = to_uint8(result[k], pconfig, data_ptr);
+                        break;
+                    case 2:
+                        err = to_uint16(result[k], pconfig, data_ptr);
+                        break;
+                    case 4:
+                        err = to_uint32(result[k], pconfig, data_ptr);
+                        break;
+                    case 8:
+                        err = to_uint64(result[k], pconfig, data_ptr);
+                        break;
+                    default:
+                        assert(0);
                 }
-                *(int8_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'B') {
-                uint8_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        size_t value = PyLong_AsSize_t(converted);
-                        if (value == (size_t)-1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (uint8_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_uint8(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
+                if (err) {
+                    read_error->error_type = err;
+                    break;
                 }
-                *(uint8_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
             }
-            else if (typecode == 'h') {
-                int16_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        long long value = PyLong_AsLongLong(converted);
-                        if (value == -1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (int16_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_int16(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
-                }
-                *(int16_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'H') {
-                uint16_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        size_t value = PyLong_AsSize_t(converted);
-                        if (value == (size_t)-1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (uint16_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_uint16(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
-                }
-                *(uint16_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'i') {
-                int32_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        long long value = PyLong_AsLongLong(converted);
-                        if (value == -1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (int32_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_int32(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
-                }
-                *(int32_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'I') {
-                uint32_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        size_t value = PyLong_AsSize_t(converted);
-                        if (value == (size_t)-1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (uint32_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_uint32(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
-                }
-                *(uint32_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'q') {
-                int64_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        long long value = PyLong_AsLongLong(converted);
-                        if (value == -1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (int64_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_int64(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
-                }
-                *(int64_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'Q') {
-                uint64_t x = 0;
-                if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        size_t value = PyLong_AsSize_t(converted);
-                        if (value == (size_t)-1) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                        x = (uint64_t) value;  // FIXME: Check out of bounds!
-                    }
-                    else {
-                        x = to_uint64(result[k], pconfig, &read_error->error_type);
-                        if (read_error->error_type) {
-                            break;
-                        }
-                    }
-                }
-                *(uint64_t *) data_ptr = x;
-                data_ptr += field_types[f].itemsize;
-            }
-            else if (typecode == 'f' || typecode == 'd') {
+            else if (typecode == 'f') {
                 // Convert to float.
                 double x = NAN;
                 if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        x = PyFloat_AsDouble(converted);
-                        if (x == -1.0) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                    }
-                    else {
-                        char32_t decimal = pconfig->decimal;
-                        char32_t sci = pconfig->sci;
-                        if ((*(result[k]) == '\0') || !to_double(result[k], &x, sci, decimal)) {
-                            read_error->error_type = ERROR_BAD_FIELD;
-                            break;
-                        }
+                    char32_t decimal = pconfig->decimal;
+                    char32_t sci = pconfig->sci;
+                    if ((*(result[k]) == '\0') || !to_double(result[k], &x, sci, decimal)) {
+                        read_error->error_type = ERROR_BAD_FIELD;
+                        break;
                     }
                 }
-                if (typecode == 'f') {
-                    *(float *) data_ptr = (float) x;
+                if (itemsize == 4) {
+                    float result = x;
+                    memcpy(data_ptr, &result, sizeof(float));
                 }
                 else {
-                    *(double *) data_ptr = x;
+                    memcpy(data_ptr, &x, sizeof(double));
                 }
-                data_ptr += field_types[f].itemsize;
             }
-            else if (typecode == 'z' || typecode == 'c') {
+            else if (typecode == 'c') {
                 // Convert to complex.
                 double x = NAN;
                 double y = NAN;
                 if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        // FIXME: This case not converted from the float/double code.
-                        x = PyFloat_AsDouble(converted);
-                        if (x == -1.0) {
-                            if (PyErr_Occurred()) {
-                                read_error->error_type = ERROR_BAD_FIELD;
-                                break;
-                            }
-                        }
-                    }
-                    else {
-                        char32_t decimal = pconfig->decimal;
-                        char32_t sci = pconfig->sci;
-                        char32_t imaginary_unit = pconfig->imaginary_unit;
-                        if ((*(result[k]) == '\0') || !to_complex(result[k], &x, &y,
-                                                                  sci, decimal,
-                                                                  imaginary_unit,
-                                                                  ALLOW_PARENS)) {
-                            read_error->error_type = ERROR_BAD_FIELD;
-                            break;
-                        }
+                    char32_t decimal = pconfig->decimal;
+                    char32_t sci = pconfig->sci;
+                    char32_t imaginary_unit = pconfig->imaginary_unit;
+                    if ((*(result[k]) == '\0') || !to_complex(result[k], &x, &y,
+                                                              sci, decimal,
+                                                              imaginary_unit,
+                                                              ALLOW_PARENS)) {
+                        read_error->error_type = ERROR_BAD_FIELD;
+                        break;
                     }
                 }
-                if (typecode == 'c') {
-                    *(complex float *) data_ptr = (complex float) (x + I*y);
+                if (itemsize == 8) {
+                    complex float result = x + I*y;
+                    memcpy(data_ptr, &result, sizeof(result));
                 }
                 else {
-                    *(complex double *) data_ptr = x + I*y;
+                    complex double result = x + I*y;
+                    memcpy(data_ptr, &result, sizeof(result));
                 }
-                data_ptr += field_types[f].itemsize;
             }
             else if (typecode == 'S') {
                 // String
-                memset(data_ptr, 0, field_types[f].itemsize);
                 if (k < current_num_fields) {
                     //strncpy(data_ptr, result[k], field_types[f].itemsize);
                     size_t i = 0;
@@ -730,50 +571,63 @@ read_rows(stream *s,
                         data_ptr[i] = result[k][i];
                         ++i;
                     }
-                    if (i < (size_t) field_types[f].itemsize) {
-                        data_ptr[i] = '\0';
-                    }
+                    memset(data_ptr + i, 0, field_types[f].itemsize - i);
                 }
-                data_ptr += field_types[f].itemsize;
+                else {
+                    memset(data_ptr, 0, field_types[f].itemsize);
+                }
             }
-            else {  // typecode == 'U'
-                memset(data_ptr, 0, field_types[f].itemsize);
+            else if (typecode == 'U') {
                 if (k < current_num_fields) {
-                    if (converted != NULL) {
-                        Py_ssize_t len;
-                        int kind;
-                        void *data;
-                        if (!PyUnicode_Check(converted)) {
-                            read_error->error_type = ERROR_BAD_FIELD;
-                            break;
-                        }
-                        len = PyUnicode_GET_LENGTH(converted);
-                        if (4*len > field_types[f].itemsize) {
-                            // XXX Make a more specific error type? Converted
-                            // Unicode string is too long.
-                            read_error->error_type = ERROR_BAD_FIELD;
-                            break;
-                        }
-                        kind = PyUnicode_KIND(converted);
-                        data = PyUnicode_DATA(converted);
-                        for (Py_ssize_t i = 0; i < len; ++i) {
-                            *(char32_t *)(data_ptr + 4*i) = PyUnicode_READ(kind, data, i);
-                        }
+                    size_t i = 0;
+                    // XXX The '4's in the following are sizeof(char32_t).
+                    while (i < (size_t) field_types[f].itemsize/4 && result[k][i]) {
+                        memcpy(data_ptr + 4*i, &result[k][i], 4);
+                        ++i;
                     }
-                    else {
-                        size_t i = 0;
-                        // XXX The '4's in the following are sizeof(char32_t).
-                        while (i < (size_t) field_types[f].itemsize/4 && result[k][i]) {
-                            *(char32_t *)(data_ptr + 4*i) = result[k][i];
-                            ++i;
-                        }
-                        if (i < (size_t) field_types[f].itemsize/4) {
-                            *(char32_t *)(data_ptr + 4*i) = '\0';
-                        }
+                    for (i *= 4; i < (size_t)field_types[f].itemsize; i++) {
+                        *(char32_t *)(data_ptr + i) = '\0';
                     }
                 }
-                data_ptr += field_types[f].itemsize;
+                else {
+                    memset(data_ptr, 0, field_types[f].itemsize);
+                }
             }
+            else {
+                /* Converts to unicode and calls custom converter (if set) */
+                converted = call_converter_function(conv_funcs[j], result[k]);
+                if (converted == NULL) {
+                    read_error->error_type = ERROR_CONVERTER_FAILED;
+                    break;
+                }
+                /* TODO: Dangerous semi-copy from PyArray_Pack which this
+                 *       should use, but cannot (it is not yet public).
+                 *       This will get some casts wrong (unlike PyArray_Pack),
+                 *       and like it (currently) does necessarily handle an
+                 *       array return correctly (but maybe that is fine).
+                 */
+                PyArrayObject_fields arr_fields = {
+                        .flags = NPY_ARRAY_WRITEABLE,  /* assume array is not behaved. */
+                };
+                Py_SET_TYPE(&arr_fields, &PyArray_Type);
+                Py_SET_REFCNT(&arr_fields, 1);
+                arr_fields.descr = field_types[f].descr;
+                int res = field_types[f].descr->f->setitem(
+                        converted, data_ptr, &arr_fields);
+                Py_DECREF(converted);
+                if (res < 0) {
+                    read_error->error_type = ERROR_CONVERTER_FAILED;
+                    break;
+                }
+                data_ptr += field_types[f].itemsize;
+                continue;
+            }
+
+            if (field_types[f].swap) {
+                /* This is awkward, but OK for the basic dtypes above */
+                field_types[f].descr->f->copyswap(data_ptr, data_ptr, 1, NULL);
+            }
+            data_ptr += field_types[f].itemsize;
         }
 
         free(result);

--- a/src/rows.h
+++ b/src/rows.h
@@ -19,7 +19,7 @@ typedef struct _read_error {
     int line_number;
     int field_number;
     int char_position;
-    char typecode;
+    PyArray_Descr *descr;
     // int32_t itemsize;  // not sure this is needed.
     int32_t column_index; // for ERROR_INVALID_COLUMN_INDEX;
 } read_error_type;

--- a/src/rows.h
+++ b/src/rows.h
@@ -37,6 +37,7 @@ read_rows(stream *s,
         int *nrows, int num_field_types, field_type *field_types,
         parser_config *pconfig, int32_t *usecols, int num_usecols,
         int skiplines, PyObject *converters, void *data_array,
-        int *num_cols, bool homogeneous, read_error_type *read_error);
+        int *num_cols, bool homogeneous, bool needs_init,
+        read_error_type *read_error);
 
 #endif

--- a/src/rows.h
+++ b/src/rows.h
@@ -37,6 +37,6 @@ read_rows(stream *s,
         int *nrows, int num_field_types, field_type *field_types,
         parser_config *pconfig, int32_t *usecols, int num_usecols,
         int skiplines, PyObject *converters, void *data_array,
-        int *num_cols, read_error_type *read_error);
+        int *num_cols, bool homogeneous, read_error_type *read_error);
 
 #endif

--- a/src/str_to_int.c
+++ b/src/str_to_int.c
@@ -1,5 +1,5 @@
 
-
+#include <string.h>
 #include "typedefs.h"
 #include "str_to.h"
 #include "error_types.h"
@@ -8,13 +8,11 @@
 
 
 #define DECLARE_TO_INT(intw, INT_MIN, INT_MAX)                                  \
-    intw##_t                                                                        \
-    to_##intw(char32_t *field, parser_config *pconfig, int *error)                  \
+    int                                                                             \
+    to_##intw(char32_t *field, parser_config *pconfig, char *ptr)                   \
     {                                                                               \
         intw##_t x;                                                                 \
         int ierror = 0;                                                             \
-                                                                                    \
-        *error = ERROR_OK;                                                          \
                                                                                     \
         x = (intw##_t) str_to_int64(field, INT_MIN, INT_MAX, &ierror);              \
         if (ierror) {                                                               \
@@ -23,27 +21,26 @@
                 char32_t decimal = pconfig->decimal;                                \
                 char32_t sci = pconfig->sci;                                        \
                 if ((*field == '\0') || !to_double(field, &fx, sci, decimal)) {     \
-                    *error = ERROR_BAD_FIELD;                                       \
+                    return ERROR_BAD_FIELD;                                         \
                 }                                                                   \
                 else {                                                              \
                     x = (intw##_t) fx;                                              \
                 }                                                                   \
             }                                                                       \
             else {                                                                  \
-                *error = ERROR_BAD_FIELD;                                           \
+                return ERROR_BAD_FIELD;                                             \
             }                                                                       \
         }                                                                           \
-        return x;                                                                   \
+        memcpy(ptr, &x, sizeof(x));                                                 \
+        return ERROR_OK;                                                            \
     }                                                                               \
 
 #define DECLARE_TO_UINT(uintw, UINT_MAX)                                            \
-    uintw##_t                                                                       \
-    to_##uintw(char32_t *field, parser_config *pconfig, int *error)                 \
+    int                                                                             \
+    to_##uintw(char32_t *field, parser_config *pconfig, char *ptr)                  \
     {                                                                               \
         uintw##_t x;                                                                \
         int ierror = 0;                                                             \
-                                                                                    \
-        *error = ERROR_OK;                                                          \
                                                                                     \
         x = (uintw##_t) str_to_uint64(field, UINT_MAX, &ierror);                    \
         if (ierror) {                                                               \
@@ -52,17 +49,18 @@
                 char32_t decimal = pconfig->decimal;                                \
                 char32_t sci = pconfig->sci;                                        \
                 if ((*field == '\0') || !to_double(field, &fx, sci, decimal)) {     \
-                    *error = ERROR_BAD_FIELD;                                       \
+                    return ERROR_BAD_FIELD;                                         \
                 }                                                                   \
                 else {                                                              \
                     x = (uintw##_t) fx;                                             \
                 }                                                                   \
             }                                                                       \
             else {                                                                  \
-                *error = ERROR_BAD_FIELD;                                           \
+                return ERROR_BAD_FIELD;                                             \
             }                                                                       \
         }                                                                           \
-        return x;                                                                   \
+        memcpy(ptr, &x, sizeof(x));                                                 \
+        return ERROR_OK;                                                            \
     }                                                                               \
 
 DECLARE_TO_INT(int8, INT8_MIN, INT8_MAX)

--- a/src/str_to_int.h
+++ b/src/str_to_int.h
@@ -4,8 +4,8 @@
 #include "typedefs.h"
 #include "parser_config.h"
 
-#define DECLARE_TO_INT_PROTOTYPE(intw)                                          \
-    intw##_t to_##intw(char32_t *field, parser_config *pconfig, int *error);    \
+#define DECLARE_TO_INT_PROTOTYPE(intw)                                    \
+    int to_##intw(char32_t *field, parser_config *pconfig, char *ptr);    \
 
 DECLARE_TO_INT_PROTOTYPE(int8)
 DECLARE_TO_INT_PROTOTYPE(int16)

--- a/src/type_inference.h
+++ b/src/type_inference.h
@@ -8,7 +8,8 @@ classify_type(char32_t *field,
         char32_t decimal, char32_t sci, char32_t imaginary_unit,
         int64_t *i, uint64_t *u, char prev_type);
 
-char
-type_for_integer_range(int64_t imin, uint64_t umax);
+void
+update_type_for_integer_range(
+        char *type, size_t *itemsize, int64_t imin, uint64_t umax);
 
 #endif


### PR DESCRIPTION
This also reorganizes a bit, and I just deleted the currently
unused `from_filename`, that seemed easier, since otherwise it
just means updating duplicated things.

I modified the type structure to rely on itemsize rather than codes.
That currently breaks some errors (because it has the incorrect
types for the fields).

In the current stage it may still crash down in flames, but it is
a start, and probably fairly far along.

---

Also invalidates a number of C-level tests probably, I did not bother about that.  And some stuff needs cleaning up: but I consider npreadtext in pretty high flux mode still, so...