### PR TITLE
MAINT: Remove whitespace special path and fix newline loadtxt incompat

### DIFF
--- a/npreadtext/_loadtxt.py
+++ b/npreadtext/_loadtxt.py
@@ -6,7 +6,7 @@ from ._readers import read
 def _loadtxt(*args, **kwds):
     delimiter = kwds.pop('delimiter', None)
     if delimiter is None:
-        delimiter = ' '
+        delimiter = ''
 
     dtype = kwds.pop('dtype', None)
     if dtype is None:

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -190,13 +190,19 @@ def test_unpack_array():
     assert_array_equal(c, np.array([3.0, 6.0, 9.0, 2.0]))
 
 
-def test_blank_lines():
-    txt = StringIO('1 2 30\n\n4 5 60\n     \n7 8 90')
-    a = read(txt, delimiter=' ')
+def test_blank_lines_spaces_delimit():
+    txt = StringIO('1 2 30\n\n4 5 60\n     \n7 8 90\n  # comment\n3 2 1')
+    a = read(txt, delimiter=' ', comment="#")
     assert_equal(a.dtype, np.uint8)
-    assert_equal(a, np.array([[1, 2, 30], [4, 5, 60], [7, 8, 90]],
+    assert_equal(a, np.array([[1, 2, 30], [4, 5, 60], [7, 8, 90], [3, 2, 1]],
                              dtype=np.uint8))
 
+def test_blank_lines_normal_delimiter():
+    txt = StringIO('1,2,30\n\n4,5,60\n\n7,8,90\n# comment\n3,2,1')
+    a = read(txt, delimiter=',', comment="#")
+    assert_equal(a.dtype, np.uint8)
+    assert_equal(a, np.array([[1, 2, 30], [4, 5, 60], [7, 8, 90], [3, 2, 1]],
+                             dtype=np.uint8))
 
 def test_max_rows():
     txt = StringIO('1.5,2.5\n3.0,4.0\n5.5,6.0')


### PR DESCRIPTION
The `ignore_leading_spaces` is sufficient to handle everything that
the whitespace loader should be doing.  Although, the whitespace
version did allow empty lines (with or without whitespace), while
the other version did not.  Just align both, a new option could maybe
be implemented to not allow it if necessary.