### PR TITLE
BUG: Allow negative usecols to use the current column number

### DIFF
--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -240,6 +240,13 @@ def test_converters_and_usecols():
     assert_equal(a, [[1.5, 3.5], [3.0, np.nan], [5.5, 7.5]])
 
 
+def test_ragged_usecols():
+    # Usecols, and negative ones, even work with variying number of columns
+    txt = StringIO('0,0,XXX\n0,XXX,0,XXX\n0,XXX,XXX,0,XXX\n')
+    a = read(txt, dtype=np.float64, usecols=[0, -2])
+    assert_equal(a, [[0, 0], [0, 0], [0, 0]])
+
+
 @pytest.mark.parametrize("c1", ["a", "の", "🫕"])
 @pytest.mark.parametrize("c2", ["a", "の", "🫕"])
 def test_large_unicode_characters(c1, c2):

--- a/src/rows.c
+++ b/src/rows.c
@@ -299,15 +299,6 @@ read_rows(stream *s,
             if (usecols == NULL) {
                 num_usecols = actual_num_fields;
             }
-            else {
-                // Normalize the values in usecols.
-                for (j = 0; j < num_usecols; ++j) {
-                    if (usecols[j] < 0) {
-                        usecols[j] += current_num_fields;
-                    }
-                    // XXX Check that the value is between 0 and current_num_fields.
-                }
-            }
 
             if (converters != Py_None) {
                 conv_funcs = create_conv_funcs(converters, usecols, num_usecols,


### PR DESCRIPTION
This means moving the normalization to each row.  That was already
there, but it was also normalized on the first row, which would
break it (by making the negative offset positive)