### PR TITLE
BUG: Raise an error for bad generator/file-like object

### DIFF
--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -359,3 +359,21 @@ def test_read_from_generator_2():
     data = read(gen(), dtype='i,d', delimiter=' ')
     expected = np.array([(0, 0.0), (1, 0.25), (2, 0.5)], dtype='i,d')
     assert_equal(data, expected)
+
+
+def test_read_from_bad_generator():
+    class BadFileLike:
+        lines = iter(["1,2", b"3,5", 12738])
+
+        def readline(self):
+            return next(self.lines)
+
+        def seek(self):
+            raise NotImplementedError
+
+        def tell(self):
+            raise NotImplementedError
+
+    with pytest.raises(TypeError,
+            match=r"object.readline\(\) returned non-string"):
+        read(BadFileLike(), dtype='i,i', delimiter=',')

--- a/src/stream_python_file_by_line.c
+++ b/src/stream_python_file_by_line.c
@@ -114,6 +114,12 @@ _fb_load(python_file_by_line *fb)
         }
         Py_SETREF(fb->line, uline);
     }
+    else if (!PyUnicode_Check(line)) {
+        PyErr_SetString(PyExc_TypeError,
+                "object.readline() returned non-string");
+        Py_CLEAR(fb->line);
+        return -1;
+    }
 
     fb->linelen = PyUnicode_GET_LENGTH(fb->line);
 


### PR DESCRIPTION
If an object fails to return a unicode or bytes object, we should
not crash the process :).