### PR TITLE
MAINT,ENH: Use Python errors directly and improve messages

### DIFF
--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -227,7 +227,8 @@ def test_max_rows(dtype):
 @pytest.mark.parametrize('dtype', [np.dtype('f8'), np.dtype('i2')])
 def test_bad_values(dtype):
     txt = StringIO('1.5,2.5\n3.0,XXX\n5.5,6.0')
-    with pytest.raises(RuntimeError, match=f'bad {dtype.name} value'):
+    msg = f"could not convert string .XXX. to {dtype} at row 1, column 2"
+    with pytest.raises(ValueError, match=msg):
         read(txt, dtype=dtype)
 
 

--- a/src/rows.h
+++ b/src/rows.h
@@ -36,7 +36,6 @@ read_rows(stream *s,
         int *nrows, int num_field_types, field_type *field_types,
         parser_config *pconfig, int32_t *usecols, int num_usecols,
         int skiplines, PyObject *converters, char *data_array,
-        int *num_cols, bool homogeneous, bool needs_init,
-        read_error_type *read_error);
+        int *num_cols, bool homogeneous, bool needs_init);
 
 #endif


### PR DESCRIPTION
This changes the error on parsing to `ValueError` in most cases.
This is something we should potentially discuss.

If we use this function as a backend for multiple entry-points
some of the "pass error out" logic would maybe be useful to
give better context in the error message (e.g. if we had two
functions with different name for `usecols`).

For now, I think I prefer this, it feels simpler to me.

---

This is the first chunk of how I envision gh-26, but there is still a lot up in the air.  I think I will just merge this in any case, since I think it is a step in the right direction.

But, I admit that the old version also has some advantage if we have a use to make this more of a "backend".  For now, I am happier with this though, and assume we won't have much need for it.