### PR TITLE
MAINT,BUG: Work arrays into the core of rows

### DIFF
--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -210,8 +210,6 @@ def read(file, *, delimiter=',', comment='#', quote='"',
             raise ValueError(f"length of usecols ({len(usecols)}) and "
                              f"number of fields in dtype ({len(codes)}) "
                              "do not match.")
-        if len(dtypes) == 1 and usecols is not None:
-            dtypes *= len(usecols)
     else:
         dtypes = None
 

--- a/src/rows.h
+++ b/src/rows.h
@@ -24,18 +24,13 @@ typedef struct _read_error {
     int32_t column_index; // for ERROR_INVALID_COLUMN_INDEX;
 } read_error_type;
 
-/*
-int analyze(FILE *f, parser_config *pconfig, int skiplines, int numrows,
-               char *datetime_fmt, int *num_fields, field_type **field_types);
 
-int count_fields(FILE *f, parser_config *pconfig, int skiprows);
-int count_rows(FILE *f, parser_config *pconfig);
-*/
-char *
+PyArrayObject *
 read_rows(stream *s,
         Py_ssize_t *nrows, int num_field_types, field_type *field_types,
-        parser_config *pconfig, int32_t *usecols, int num_usecols,
-        Py_ssize_t skiplines, PyObject *converters, char *data_array,
-        int *num_cols, bool homogeneous, bool needs_init);
+        parser_config *pconfig, int num_usecols, int *usecols,
+        Py_ssize_t skiplines, PyObject *converters,
+        PyArrayObject *data_array, PyArray_Descr *out_descr,
+        bool homogeneous);
 
 #endif


### PR DESCRIPTION
While working with arrays in the row reader is a bit annoying in
parts (because why?).  It also is somewhat necessary unfortunately.

This solves the problem that having the array already ready
greatly simplifies cleanup when the result has an object dtype.

(It also is a bit nicer for growing the strings, since we can just
use the NumPy API to copy.)

I don't think this is really much nicer and if NumPy grows better
API to decref a chunk of memory content, rather than relying on
having the array object around it would be worse probably...

But this is what we got currently, mutating/creating the array
object inside `read_rows` just seems more practical