### PR TITLE
MAINT: Remove XOPEN_SOURCE definition from C files

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -1,6 +1,3 @@
-
-#define _XOPEN_SOURCE 700
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/type_inference.c
+++ b/src/type_inference.c
@@ -1,5 +1,3 @@
-#define _XOPEN_SOURCE
-
 #include <Python.h>
 
 #include <stdio.h>


### PR DESCRIPTION
As far as I understand this was necessary for datetime support.
We don't support datetime (explicitly), so don't worry about it for
now.
Another reason to remove the macro, is that I am also not sure how
portable it actually is.