### PR TITLE
Add header files to extension include_dir.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def configuration(parent_package='', top_path=None):
     config.add_extension(
             'npreadtext._readtextmodule',
             sources=[path.join('src', t) for t in cfiles],
-            include_dirs=[numpy.get_include()],)
+            include_dirs=[numpy.get_include(), "src"],)
     return config
 
 


### PR DESCRIPTION
This is necessary (I think) to make the package installable via pip from somewhere other than the source directory.