### PR TITLE
BUG: Correctly check for out-of-bound unicode characters

### DIFF
--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -128,10 +128,6 @@ def read(file, *, delimiter=',', comment='#', quote='"',
         raise TypeError("a dtype must be provided.")
     dtype = np.dtype(dtype)
 
-    # FIXME: Temporary hack just to get some loadtxt test to pass!
-    ##if dtype == np.dtype('U0'):
-    ##    dtype = np.dtype('U32')
-
     if usecols is not None:
         # Allow usecols to be a single int or a sequence of ints
         try:

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -413,3 +413,13 @@ def test_bad_encoding():
 
     with pytest.raises(LookupError):
         read(data, encoding="this encoding is invalid!")
+
+
+def test_character_not_bytes_compatible():
+    # Test a character which cannot be encoded as "S".  Note that loadtxt
+    # would try `string.encode("latin1")` throwing a slightly more informative
+    # `UnicodeDecodeError`.
+    data = ["–"]
+
+    with pytest.raises(ValueError):
+        read(data, dtype="S5")

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -189,7 +189,6 @@ to_cfloat(PyArray_Descr *descr,
 }
 
 
-
 int
 to_cdouble(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
@@ -278,14 +277,10 @@ call_converter_function(PyObject *func, const Py_UCS4 *str, size_t length)
 {
     PyObject *s = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, str, length);
     if (s == NULL || func == NULL) {
-        // fprintf(stderr, "*** PyUnicode_FromKindAndData failed ***\n");
         return s;
     }
     PyObject *result = PyObject_CallFunctionObjArgs(func, s, NULL);
     Py_DECREF(s);
-    if (result == NULL) {
-        // fprintf(stderr, "*** PyObject_CallFunctionObjArgs failed ***\n");
-    }
     return result;
 }
 

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -233,8 +233,15 @@ to_string(PyArray_Descr *descr,
 
     for (size_t i = 0; i < length; i++) {
         if (c < end) {
-            // TODO: This cast is wrong as it really should be encoding/error?!
-            dataptr[i] = (char)(*c);
+            /*
+             * loadtxt assumed latin1, which is compatible with UCS1 (first
+             * 256 unicode characters).
+             */
+            if (NPY_UNLIKELY(*c > 255)) {
+                /* TODO: Was UnicodeDecodeError, is unspecific error good? */
+                return -1;
+            }
+            dataptr[i] = (Py_UCS1)(*c);
             c++;
         }
         else {

--- a/src/stream_pyobject.c
+++ b/src/stream_pyobject.c
@@ -47,8 +47,6 @@ typedef struct {
  * Helper function to support byte objects as well as unicode strings.
  *
  * NOTE: Steals a reference to `str` (although usually returns it unmodified).
- *
- * TODO: Make encoding a char *, the utf-8 default also should be incorrect.
  */
 static NPY_INLINE PyObject *
 process_stringlike(PyObject *str, char *encoding)

--- a/src/stream_pyobject.h
+++ b/src/stream_pyobject.h
@@ -8,9 +8,9 @@
 #include "stream.h"
 
 stream *
-stream_python_file(PyObject *obj, PyObject *encoding);
+stream_python_file(PyObject *obj, char *encoding);
 
 stream *
-stream_python_iterable(PyObject *obj, PyObject *encoding);
+stream_python_iterable(PyObject *obj, char *encoding);
 
 #endif


### PR DESCRIPTION
We assume that "casting" to bytes/S dtype is OK so long we are
in the latin1 range (which is compatible to unicode).
Otherwise, we just fail.

I left a TODO in the code, raising the generic `ValueError`, may not be best here.  (And it used to be a UnicodeDecodeError.)

---

The PR includes a few cleanups/maintanence fixes.