### PR TITLE
BUG: Fix converters to work like loadtxt

### DIFF
--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -172,20 +172,6 @@ def read(fname, *, delimiter=',', comment='#', quote='"',
         usecols = np.array([operator.index(i) for i in usecols_as_list],
                            dtype=np.int32)
 
-    if converters is not None:
-        if not isinstance(converters, dict):
-            raise TypeError('converters must be a dictionary')
-        for key, func in converters.items():
-            try:
-                operator.index(key)
-            except TypeError:
-                raise TypeError('keys of the converters dictionary must '
-                                f'be integers; got {key!r}') from None
-            if not callable(func):
-                raise TypeError('values of the converters dictionary must '
-                                'be callable, but the value associated with '
-                                f'the key {key!r} is not')
-
     if ndmin not in [None, 0, 1, 2]:
         raise ValueError(f'ndmin must be None, 0, 1, or 2; got {ndmin}')
 

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -250,7 +250,8 @@ def test_converters():
 def test_converters_and_usecols():
     txt = StringIO('1.5,2.5,3.5\n3.0,4.0,XXX\n5.5,6.0,7.5\n')
     conv = {-1: lambda s: np.nan if s == 'XXX' else float(s)}
-    a = read(txt, dtype=np.float64, converters=conv, usecols=[0, 2], encoding=None)
+    a = read(txt, dtype=np.float64, converters=conv,
+             usecols=[0, -1], encoding=None)
     assert_equal(a, [[1.5, 3.5], [3.0, np.nan], [5.5, 7.5]])
 
 

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -438,3 +438,32 @@ def test_character_not_bytes_compatible():
 
     with pytest.raises(ValueError):
         read(data, dtype="S5")
+
+
+def test_convert_raises_non_dict():
+    data = StringIO("1 2\n3 4")
+    with pytest.raises(TypeError, match="converters must be a dict"):
+        read(data, converters=0)
+
+
+def test_converter_raises_non_integer_key():
+    data = StringIO("1 2\n3 4")
+    with pytest.raises(TypeError, match="keys of the converters dict"):
+        read(data, converters={"a": int})
+    with pytest.raises(TypeError, match="keys of the converters dict"):
+        read(data, converters={"a": int}, usecols=0)
+
+
+@pytest.mark.parametrize("bad_col_ind", (3, -3))
+def test_converter_raises_non_column_key(bad_col_ind):
+    data = StringIO("1 2\n3 4")
+    with pytest.raises(ValueError, match="converter specified for column"):
+        read(data, converters={bad_col_ind: int})
+
+
+def test_converter_raises_value_not_callable():
+    data = StringIO("1 2\n3 4")
+    with pytest.raises(
+        TypeError, match="values of the converters dictionary must be callable"
+    ):
+        read(data, converters={0: 1})


### PR DESCRIPTION
This attempts to align converter logic to be as it is right now
for loadtxt (as imperfect that is).  The only thing we don't do
the same way is that:
1. Non-integer converters don't get ignored when usecols are used
2. We don't support duck-typed `obj.items()` but enforce a dict.