### PR TITLE
ENH: Chain exceptions if parsing a field failed.

### DIFF
--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -401,8 +401,7 @@ def test_object_cleanup_on_read_error():
 
     txt = StringIO("x\n" * 10000)
 
-    # note that this could be a chained ValueError instead:
-    with pytest.raises(ValueError, match="failed half-way through!"):
+    with pytest.raises(ValueError, match="at row 5000, column 1"):
         read(txt, dtype=object, converters={0: conv})
 
     assert sys.getrefcount(sentinel) == 2


### PR DESCRIPTION
This chains the exception for now, something that I thought might be nice, but initially did not do when I worked on it:

This leads (for example) to the following as of now:
```python
In [5]: read(["asdf", "fdsa"], dtype="int", converters={0: int})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
ValueError: invalid literal for int() with base 10: 'asdf'

The above exception was the direct cause of the following exception:

ValueError                                Traceback (most recent call last)
<ipython-input-5-f78ed236dfab> in <module>
----> 1 read(["asdf", "fdsa"], dtype="int", converters={0: int})

~/forks/npreadtext/npreadtext/_readers.py in read(file, delimiter, comment, quote, decimal, sci, imaginary_unit, usecols, skiprows, max_rows, converters, ndmin, unpack, dtype, encoding)
    249             file = _preprocess_comments(file, comments, encoding)
    250 
--> 251         arr = _readtext_from_file_object(
    252             file, delimiter=delimiter, comment=comment, quote=quote,
    253             decimal=decimal, sci=sci, imaginary_unit=imaginary_unit,

ValueError: could not convert string 'asdf' to int64 at row 0, column 1.
```