### PR TITLE
BUG,MAINT: Move dtype "discovery" to python (including string size)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu, macos, windows]
         python-version: [3.7, 3.8, 3.9]
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
-        compat-test-ignore: ["test_converters_nodecode,test_from_float_hex"]
+        compat-test-ignore: ["test_from_float_hex"]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -128,7 +128,8 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
                              "usecols", "skiprows",
                              "max_rows", "converters",
                              "dtype", "dtypes",
-                             "encoding", "filelike", "byte_converters",
+                             "encoding", "filelike",
+                             "byte_converters", "c_byte_converters",
                              NULL};
     PyObject *file;
     Py_ssize_t skiprows = 0;
@@ -155,14 +156,16 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
         .delimiter_is_whitespace = false,
         .ignore_leading_whitespace = false,
         .python_byte_converters = false,
+        .c_byte_converters = false,
     };
     int python_byte_converters = 0;
+    int c_byte_converters = 0;
 
     PyObject *arr = NULL;
     int num_dtype_fields;
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "O|$O&O&O&O&O&O&OnnOOOzpp", kwlist,
+            args, kwargs, "O|$O&O&O&O&O&O&OnnOOOzppp", kwlist,
             &file,
             &parse_control_character, &pc.delimiter,
             &parse_control_character, &pc.comment,
@@ -172,10 +175,11 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
             &parse_control_character, &pc.imaginary_unit,
             &usecols, &skiprows, &max_rows, &converters,
             &dtype, &dtypes_obj, &encoding, &filelike,
-            &python_byte_converters)) {
+            &python_byte_converters, &c_byte_converters)) {
         return NULL;
     }
     pc.python_byte_converters = python_byte_converters;
+    pc.c_byte_converters = c_byte_converters;
 
     if (pc.delimiter == (Py_UCS4)-1) {
         /* TODO: We can allow a '\0' delimiter; need to refine argparsing */

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -315,6 +315,13 @@ to_generic_with_converter(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *config, PyObject *func)
 {
+    bool use_byte_converter = false;
+    if (func == NULL) {
+        use_byte_converter = config->python_byte_converters;
+    }
+    else {
+        use_byte_converter = config->c_byte_converters;
+    }
     /* Converts to unicode and calls custom converter (if set) */
     PyObject *converted = call_converter_function(
             func, str, (size_t)(end - str), config->python_byte_converters);

--- a/src/parser_config.h
+++ b/src/parser_config.h
@@ -78,8 +78,13 @@ typedef struct _parser_config {
      /*
       * Data should be encoded as `latin1` when using python converter
       * (implementing `loadtxt` default Python 2 compatibility mode).
+      * The c byte converter is used when the user requested `dtype="S"`.
+      * In this case we go via `dtype=object`, however, loadtxt allows latin1
+      * while normal object to string casts only accept ASCII, so it ensures
+      * that that the object array already contains bytes and not strings.
       */
      bool python_byte_converters;
+     bool c_byte_converters;
 } parser_config;
 
 parser_config


### PR DESCRIPTION
This will fix the dtype discovery for datetimes and with converters.
It of course also should significantly slow things down if the
string size needs to be discovered.

---

Marking as draft, I will have to rebase it on the byte-converter stuff.  In particular, the byte-converter flag will be helpful/necessary here to ensure we put byte-strings into the object array when the final result is of "S" dtype.

This probably needs a bit more refactor and it does move some paths back into Python for simplicity...

EDIT: Would address gh-74 and gh-34
