### PR TITLE
BUG: loadtxt compatibility: handle byte converters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu, macos, windows]
         python-version: [3.7, 3.8, 3.9]
         numpy-version: [1.19.*, 1.20.*, 1.21.*]
-        compat-test-ignore: ["test_converters_decode,test_converters_nodecode,test_from_float_hex"]
+        compat-test-ignore: ["test_converters_nodecode,test_from_float_hex"]
 
     steps:
     - uses: actions/checkout@v2

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -36,7 +36,7 @@ def read(file, *, delimiter=',', comment='#', quote='"',
          decimal='.', sci='E', imaginary_unit='j',
          usecols=None, skiprows=0,
          max_rows=None, converters=None, ndmin=None, unpack=False,
-         dtype=np.float64, encoding=None):
+         dtype=np.float64, encoding="bytes"):
     r"""
     Read a NumPy array from a text file.
 
@@ -73,6 +73,13 @@ def read(file, *, delimiter=',', comment='#', quote='"',
     max_rows : int, optional
         Maximum number of rows of data to read.  Default is to read the
         entire file.
+    converters : dict, optional
+        A dictionary mapping column number to a function that will parse the
+        column string into the desired value. E.g. if column 0 is a date
+        string: ``converters = {0: datestr2num}``. Converters can also be used
+        to provide a default value for missing data, e.g.
+        ``converters = {3: lambda s: float(s.strip() or 0)}``.
+        Default: None
     ndmin : int, optional
         Minimum dimension of the array returned.
         Allowed values are 0, 1 or 2.  Default is 0.
@@ -84,7 +91,12 @@ def read(file, *, delimiter=',', comment='#', quote='"',
         A NumPy dtype instance, can be a structured dtype to map to the
         columns of the file.
     encoding : str, optional
-        Specifies the encoding of the input file.
+        Encoding used to decode the inputfile. The special value 'bytes'
+        (the default) enables backwards-compatible behavior for `converters`,
+        ensuring that inputs to the converter functions are encoded
+        bytes objects. The special value 'bytes' has no additional effect if
+        ``converters=None``. If encoding is ``'bytes'`` or ``None``, the
+        default system encoding is used.
 
     Returns
     -------
@@ -115,6 +127,12 @@ def read(file, *, delimiter=',', comment='#', quote='"',
     array([(1. , 10, b'alpha'), (2.3, 25, b'beta'), (4.5, 16, b'gamma')],
           dtype=[('f0', '<f8'), ('f1', 'u1'), ('f2', 'S5')])
     """
+    # Handle special 'bytes' keyword for encoding
+    byte_converters = False
+    if encoding == 'bytes':
+        encoding = None
+        byte_converters = True
+
     # TODO: encoding needs a bit closer look still to compare with loadtxt.
     #       1. loadtxt tries to guess encoding from the object.
     #       2. Does loadtxt actually use the preferred encoding, or only
@@ -237,7 +255,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
                     decimal=decimal, sci=sci, imaginary_unit=imaginary_unit,
                     usecols=usecols, skiprows=skiprows, max_rows=max_rows,
                     converters=converters, dtype=dtype, dtypes=dtypes,
-                    encoding=encoding, filelike=comments is None)
+                    encoding=encoding, filelike=comments is None,
+                    byte_converters=byte_converters)
         finally:
             f.close()
     else:
@@ -253,7 +272,8 @@ def read(file, *, delimiter=',', comment='#', quote='"',
             decimal=decimal, sci=sci, imaginary_unit=imaginary_unit,
             usecols=usecols, skiprows=skiprows, max_rows=max_rows,
             converters=converters, dtype=dtype, dtypes=dtypes,
-            encoding=encoding, filelike=False)
+            encoding=encoding, filelike=False,
+            byte_converters=byte_converters)
 
     if ndmin is not None:
         # Handle non-None ndmin like np.loadtxt.  Might change this eventually?

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -162,7 +162,7 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     int num_dtype_fields;
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "O|$O&O&O&O&O&O&OnnOOOspp", kwlist,
+            args, kwargs, "O|$O&O&O&O&O&O&OnnOOOzpp", kwlist,
             &file,
             &parse_control_character, &pc.delimiter,
             &parse_control_character, &pc.comment,

--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -128,7 +128,8 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
                              "usecols", "skiprows",
                              "max_rows", "converters",
                              "dtype", "dtypes",
-                             "encoding", "filelike", NULL};
+                             "encoding", "filelike", "byte_converters",
+                             NULL};
     PyObject *file;
     Py_ssize_t skiprows = 0;
     Py_ssize_t max_rows = -1;
@@ -153,13 +154,15 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
         .allow_embedded_newline = true,
         .delimiter_is_whitespace = false,
         .ignore_leading_whitespace = false,
+        .python_byte_converters = false,
     };
+    int python_byte_converters = 0;
 
     PyObject *arr = NULL;
     int num_dtype_fields;
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "O|$O&O&O&O&O&O&OnnOOOsp", kwlist,
+            args, kwargs, "O|$O&O&O&O&O&O&OnnOOOspp", kwlist,
             &file,
             &parse_control_character, &pc.delimiter,
             &parse_control_character, &pc.comment,
@@ -168,9 +171,11 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
             &parse_control_character, &pc.sci,
             &parse_control_character, &pc.imaginary_unit,
             &usecols, &skiprows, &max_rows, &converters,
-            &dtype, &dtypes_obj, &encoding, &filelike)) {
+            &dtype, &dtypes_obj, &encoding, &filelike,
+            &python_byte_converters)) {
         return NULL;
     }
+    pc.python_byte_converters = python_byte_converters;
 
     if (pc.delimiter == (Py_UCS4)-1) {
         /* TODO: We can allow a '\0' delimiter; need to refine argparsing */

--- a/src/parser_config.h
+++ b/src/parser_config.h
@@ -75,7 +75,11 @@ typedef struct _parser_config {
       *  integer type.
       */
      bool allow_float_for_int;
-
+     /*
+      * Data should be encoded as `latin1` when using python converter
+      * (implementing `loadtxt` default Python 2 compatibility mode).
+      */
+     bool python_byte_converters;
 } parser_config;
 
 parser_config


### PR DESCRIPTION
Adds support for byte-converters and reorganizes the file opening to match the current loadtxt file opening strategy much more closely.

This is based on gh-7 and supersedes it.  It does not include the changes to the string size detection.  That is because right now I tend towards the "python solution" see gh-76