### PR TITLE
ENH: Introduce from npreadtext import monkeypatch_numpy

### DIFF
--- a/npreadtext/__init__.py
+++ b/npreadtext/__init__.py
@@ -1,5 +1,4 @@
 from ._readers import read
 from ._loadtxt import _loadtxt
 
-
 __version__ = "0.0.1.dev1"

--- a/npreadtext/_loadtxt.py
+++ b/npreadtext/_loadtxt.py
@@ -3,46 +3,50 @@ import numpy as np
 from ._readers import read
 
 
-def _loadtxt(*args, **kwds):
-    delimiter = kwds.pop('delimiter', None)
+def _loadtxt(fname, dtype=float, comments='#', delimiter=None,
+             converters=None, skiprows=0, usecols=None, unpack=False,
+             ndmin=0, encoding='bytes', max_rows=None, **kwargs):
+    """
+    Monkeypatched version of `np.loadtxt`.  Unlike loadtxt it allows some
+    additional keyword arguments, such as `quote='"'`.
+    Please check `npreadtxt.read` for details.
+
+    """
     if delimiter is None:
         delimiter = ''
+    elif isinstance(delimiter, bytes):
+        delimiter.decode("latin1")
 
-    dtype = kwds.pop('dtype', None)
     if dtype is None:
         dtype = np.float64
 
-    ndmin = kwds.pop('ndmin', None)
     if ndmin is None:
         ndmin = 0
     if ndmin not in [0, 1, 2]:
         raise ValueError(f'Illegal value of ndmin keyword: {ndmin}')
 
-    comment = kwds.pop('comments', None)
+    comment = comments
     # Type conversions for Py3 convenience
     if comment is None:
-        comment = '#'
+        comment = ''
     else:
         if isinstance(comment, (str, bytes)):
             comment = [comment]
         comment = [x.decode('latin1') if isinstance(x, bytes) else x for x in comment]
 
-    try:
-        arr = read(*args, delimiter=delimiter, dtype=dtype,
-                   comment=comment, quote='', **kwds)
-    except RuntimeError as exc:
-        raise ValueError(exc.args) from None
+    # Disable quoting unless passed:
+    quote = kwargs.pop('quote', '')
 
-    # For now, ignore 'ndmin' if 'unpack' was given.
-    if 'unpack' not in kwds:
-        if arr.shape == (0, 0):
-            arr.resize((0, 1))
-        if ndmin == 2:
-            if arr.shape == (0, 0):
-                arr = arr.reshape((0, 1))
-        elif ndmin == 1:
-            arr = np.atleast_1d(np.squeeze(arr))
-        else:
-            arr = np.squeeze(arr)
+    arr = read(fname, dtype=dtype, comment=comment, delimiter=delimiter,
+               converters=converters, skiprows=skiprows, usecols=usecols,
+               unpack=unpack, ndmin=ndmin, encoding=encoding,
+               max_rows=max_rows, quote=quote, **kwargs)
 
     return arr
+
+
+try:
+    # Try giving some reasonable docs, but __doc__ could be None.
+    _loadtxt.__doc__ += np.loadtxt.__doc__
+except:
+    pass

--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -234,7 +234,7 @@ def read(fname, *, delimiter=',', comment='#', quote='"',
     filelike = False
     try:
         if isinstance(fname, os.PathLike):
-            fname = os_fspath(fname)
+            fname = os.fspath(fname)
         # TODO: loadtxt actually uses `file + ''` to decide this?!
         if isinstance(fname, str):
             fh = np.lib._datasource.open(fname, 'rt', encoding=encoding)

--- a/npreadtext/monkeypatch_numpy.py
+++ b/npreadtext/monkeypatch_numpy.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from . import _loadtxt
+
+import warnings
+warnings.warn(
+    "This version of `npreadtext` is meant for testing purposes only; "
+    "the proposal is to integrate it into NumPy.\n"
+    "Monkeypatching NumPy should not be used for production code.")
+
+
+np.loadtxt = _loadtxt
+np.lib.loadtxt = _loadtxt
+np.lib.npyio.loadtxt = _loadtxt

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -284,7 +284,7 @@ call_converter_function(
         PyObject *func, const Py_UCS4 *str, size_t length, bool byte_converters)
 {
     PyObject *s = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, str, length);
-    if (s == NULL || func == NULL) {
+    if (s == NULL) {
         return s;
     }
     if (byte_converters) {
@@ -292,6 +292,9 @@ call_converter_function(
         if (s == NULL) {
             return NULL;
         }
+    }
+    if (func == NULL) {
+        return s;
     }
     PyObject *result = PyObject_CallFunctionObjArgs(func, s, NULL);
     Py_DECREF(s);
@@ -315,16 +318,16 @@ to_generic_with_converter(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *config, PyObject *func)
 {
-    bool use_byte_converter = false;
+    bool use_byte_converter;
     if (func == NULL) {
-        use_byte_converter = config->python_byte_converters;
+        use_byte_converter = config->c_byte_converters;
     }
     else {
-        use_byte_converter = config->c_byte_converters;
+        use_byte_converter = config->python_byte_converters;
     }
     /* Converts to unicode and calls custom converter (if set) */
     PyObject *converted = call_converter_function(
-            func, str, (size_t)(end - str), config->python_byte_converters);
+            func, str, (size_t)(end - str), use_byte_converter);
     if (converted == NULL) {
         return -1;
     }


### PR DESCRIPTION
This allows:
```
from npreadtext import monkeypatch_numpy
```
printing out a warning and then replacing `loadtxt` in NumPy with our version.  It also does some smaller fixups first (and two small bug-fixes, grrr).