### PR TITLE
BUG: Catch all unicode "whitespaces" when parsing numbers

### DIFF
--- a/src/dtoa_modified.c
+++ b/src/dtoa_modified.c
@@ -1473,7 +1473,7 @@ _Py_dg_strtod_modified(const Py_UCS4 *s00, Py_UCS4 **se, int *perror,
     s = s00;
 
     // Skip initial whitespace.
-    while (isspace(*s)) {
+    while (Py_UNICODE_ISSPACE(*s)) {
         ++s;
     }
 
@@ -1596,7 +1596,7 @@ _Py_dg_strtod_modified(const Py_UCS4 *s00, Py_UCS4 **se, int *perror,
         // Skip trailing whitespace
         // XXX Ensure that this doesn't violate some assumption
         // about s after the exponent has been parsed.
-        while (isspace(*s)) {
+        while (Py_UNICODE_ISSPACE(*s)) {
             ++s;
         }
     }

--- a/src/str_to.h
+++ b/src/str_to.h
@@ -42,7 +42,7 @@ str_to_int64(
     int d;
 
     // Skip leading spaces.
-    while (isspace(*p)) {
+    while (Py_UNICODE_ISSPACE(*p)) {
         ++p;
     }
 
@@ -104,7 +104,7 @@ str_to_int64(
     }
 
     // Skip trailing spaces.
-    while (isspace(*p)) {
+    while (Py_UNICODE_ISSPACE(*p)) {
         ++p;
     }
 
@@ -130,7 +130,7 @@ str_to_uint64(const Py_UCS4 *p_item, uint64_t uint_max, int *error)
     int d;
 
     // Skip leading spaces.
-    while (isspace(*p)) {
+    while (Py_UNICODE_ISSPACE(*p)) {
         ++p;
     }
 
@@ -169,7 +169,7 @@ str_to_uint64(const Py_UCS4 *p_item, uint64_t uint_max, int *error)
     }
 
     // Skip trailing spaces.
-    while (isspace(*p)) {
+    while (Py_UNICODE_ISSPACE(*p)) {
         ++p;
     }
 


### PR DESCRIPTION
We could discuss rolling some of this back, but Python allows any
whitespace in numbers (e.g. even newlines if this is a quoted field).
This will probably slow parsing down an inkling, so if we want we
may be able to recover some of that.

But for now, it seems like the correct/safe thing to do.