### PR TITLE
BUG: Swap `\n` and `\r` in the `\r\n` support

### DIFF
--- a/src/tokenize.c.src
+++ b/src/tokenize.c.src
@@ -147,11 +147,11 @@ tokenizer_core_@type@(tokenizer_state *ts, parser_config *const config)
         case TOKENIZE_UNQUOTED:
             chunk_start = pos;
             for (; pos < stop; pos++) {
-                if (*pos == '\n') {
+                if (*pos == '\r') {
                     ts->state = TOKENIZE_EAT_CRLF;
                     break;
                 }
-                else if (*pos == '\r') {
+                else if (*pos == '\n') {
                     ts->state = TOKENIZE_LINE_END;
                     break;
                 }
@@ -174,11 +174,11 @@ tokenizer_core_@type@(tokenizer_state *ts, parser_config *const config)
             /* Note, this branch is largely identical to `TOKENIZE_UNQUOTED` */
             chunk_start = pos;
             for (; pos < stop; pos++) {
-                if (*pos == '\n') {
+                if (*pos == '\r') {
                     ts->state = TOKENIZE_EAT_CRLF;
                     break;
                 }
-                else if (*pos == '\r') {
+                else if (*pos == '\n') {
                     ts->state = TOKENIZE_LINE_END;
                     break;
                 }
@@ -201,11 +201,11 @@ tokenizer_core_@type@(tokenizer_state *ts, parser_config *const config)
             chunk_start = pos;
             for (; pos < stop; pos++) {
                 if (!config->allow_embedded_newline) {
-                    if (*pos == '\n') {
+                    if (*pos == '\r') {
                         ts->state = TOKENIZE_EAT_CRLF;
                         break;
                     }
-                    else if (*pos == '\r') {
+                    else if (*pos == '\n') {
                         ts->state = TOKENIZE_LINE_END;
                         break;
                     }


### PR DESCRIPTION
I just had it wrong in most places, but since all that typically
happens would be inserting a blank line, it is hard to notice.

I had a fix already, but that actually made it possible to modify
the newline (and carriage) character (useful for `linterminator`
support other than universal-newline, also potentially useful to
ignore newline characters when the user passes a list of strings).

In any case, since we don't need that right now, this just swaps
fixes the logic for now.