### PR TITLE
Add note about pandas float parsing to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,15 +97,16 @@ e.g.
 
    ipython -i bench/bench.py
 
-.. note:: Comparing with ``pandas``
+Comparing with ``pandas``
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   By default, ``pandas.read_csv`` uses an approximate method for parsing
-   floating point numbers. In practice, this results in faster float parsing
-   at the expense of faithful full-precision reproduction of floating point
-   values on reading/writing. Full-precision float parsing can be selected
-   using the ``float_precision="round-trip"`` to ``pandas.read_csv``.
+By default, ``pandas.read_csv`` uses an approximate method for parsing
+floating point numbers. In practice, this results in faster float parsing
+at the expense of faithful full-precision reproduction of floating point
+values on reading/writing. Full-precision float parsing can be selected
+using the ``float_precision="round-trip"`` to ``pandas.read_csv``.
 
-   .. seealso::
+See also:
 
-      https://pandas.pydata.org/docs/user_guide/io.html#specifying-method-for-floating-point-conversion
-      https://github.com/pandas-dev/pandas/issues/17154
+- https://pandas.pydata.org/docs/user_guide/io.html#specifying-method-for-floating-point-conversion
+- https://github.com/pandas-dev/pandas/issues/17154

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ By default, ``pandas.read_csv`` uses an approximate method for parsing
 floating point numbers. In practice, this results in faster float parsing
 at the expense of faithful full-precision reproduction of floating point
 values on reading/writing. Full-precision float parsing can be selected
-using the ``float_precision="round-trip"`` to ``pandas.read_csv``.
+using the ``float_precision="round-trip"`` option of ``pandas.read_csv``.
 
 See also:
 

--- a/README.rst
+++ b/README.rst
@@ -96,3 +96,16 @@ e.g.
 .. code-block:: bash
 
    ipython -i bench/bench.py
+
+.. note:: Comparing with ``pandas``
+
+   By default, ``pandas.read_csv`` uses an approximate method for parsing
+   floating point numbers. In practice, this results in faster float parsing
+   at the expense of faithful full-precision reproduction of floating point
+   values on reading/writing. Full-precision float parsing can be selected
+   using the ``float_precision="round-trip"`` to ``pandas.read_csv``.
+
+   .. seealso::
+
+      https://pandas.pydata.org/docs/user_guide/io.html#specifying-method-for-floating-point-conversion
+      https://github.com/pandas-dev/pandas/issues/17154


### PR DESCRIPTION
Trying to do a better job of documenting some of these nuggets. We should probably collate things like this in a more formal document somewhere/someday, but adding to the README for now. Adds a couple relevant links for further info.