### PR TITLE
BUG: Implement boolean conversion largly equivalent to loadtxt

### DIFF
--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -347,6 +347,15 @@ def test_float_conversion():
     assert_equal(a, expected)
 
 
+def test_bool():
+    # Simple test for bool via integer:
+    res = read(["1, 0", "10, -1"], dtype=bool)
+    assert res.dtype == bool
+    assert_array_equal(res, [[True, False], [True, True]])
+    # Make sure we use only 1 and 0 on the byte-level:
+    assert_array_equal(res.view(np.uint8), [[1, 0], [1, 1]])
+
+
 @pytest.mark.parametrize('dt', [np.int8, np.int16, np.int32, np.int64,
                                 np.uint8, np.uint16, np.uint32, np.uint64])
 def test_cast_float_to_int(dt):

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -9,12 +9,33 @@
 #include <stdbool.h>
 
 #include "conversions.h"
+#include "str_to.h"
 
 
 double
 _Py_dg_strtod_modified(
         const Py_UCS4 *s00, Py_UCS4 **se, int *error,
         Py_UCS4 decimal, Py_UCS4 sci, bool skip_trailing);
+
+
+/*
+ * Coercion to boolean is done via integer right now.
+ * TODO: Like the integer code, does not handle embedded \0 characters!
+ */
+int
+to_bool(PyArray_Descr *NPY_UNUSED(descr),
+        const Py_UCS4 *str, const Py_UCS4 *NPY_UNUSED(end), char *dataptr,
+        parser_config *NPY_UNUSED(pconfig))
+{
+    int error = 0;
+    int64_t res = str_to_int64(str, INT64_MIN, INT64_MAX, &error);
+    if (error) {
+        return -1;
+    }
+    *dataptr = (res != 0);
+    return 0;
+}
+
 
 /*
  *  `item` must be the nul-terminated string that is to be
@@ -58,7 +79,7 @@ to_float(PyArray_Descr *descr,
 }
 
 
-/* Note: Currently used in the iteger code as a fallback */
+/* Note: Currently used in the integer code as a fallback */
 bool
 to_double_raw(const Py_UCS4 *str, double *res, Py_UCS4 decimal, Py_UCS4 sci)
 {

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -11,6 +11,11 @@
 #include "numpy/arrayobject.h"
 
 int
+to_bool(PyArray_Descr *descr,
+        const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
+        parser_config *pconfig);
+
+int
 to_float(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -51,7 +51,11 @@ field_types_init_descriptors(int num_field_types, field_type *ft)
             continue;
         }
 
-        if (ft[i].typecode == 'i') {
+        if (ft[i].typecode == '?') {
+            typenum = NPY_BOOL;
+            ft[i].set_from_ucs4 = &to_bool;
+        }
+        else if (ft[i].typecode == 'i') {
             size_t itemsize = ft[i].itemsize;
             switch (itemsize) {
                 case 1:
@@ -156,7 +160,10 @@ field_types_create(int num_field_types, PyArray_Descr *dtypes[])
     }
     for (int i = 0; i < num_field_types; ++i) {
         PyArray_Descr *descr = dtypes[i];
-        if (PyDataType_ISSIGNED(descr)) {
+        if (PyDataType_ISBOOL(descr)) {
+            ft[i].typecode = '?';
+        }
+        else if (PyDataType_ISSIGNED(descr)) {
             ft[i].typecode = 'i';
         }
         else if (PyDataType_ISUNSIGNED(descr)) {


### PR DESCRIPTION
Bools currently work via integers.  It may make sense to change
that or limit it, but probably not in the first step.

Closes gh-67