### PR TITLE
BUG,MAINT: Partially clean up integer parsing with embedded NUL

### DIFF
--- a/src/conversions.c
+++ b/src/conversions.c
@@ -24,12 +24,11 @@ _Py_dg_strtod_modified(
  */
 int
 to_bool(PyArray_Descr *NPY_UNUSED(descr),
-        const Py_UCS4 *str, const Py_UCS4 *NPY_UNUSED(end), char *dataptr,
+        const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *NPY_UNUSED(pconfig))
 {
-    int error = 0;
-    int64_t res = str_to_int64(str, INT64_MIN, INT64_MAX, &error);
-    if (error) {
+    int64_t res;
+    if (str_to_int64(str, end, INT64_MIN, INT64_MAX, &res) < 0) {
         return -1;
     }
     *dataptr = (res != 0);

--- a/src/str_to_int.c
+++ b/src/str_to_int.c
@@ -15,11 +15,10 @@
             const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,                  \
             parser_config *pconfig)                                                 \
     {                                                                               \
+        int64_t parsed;                                                             \
         intw##_t x;                                                                 \
-        int ierror = 0;                                                             \
                                                                                     \
-        x = (intw##_t) str_to_int64(str, INT_MIN, INT_MAX, &ierror);                \
-        if (ierror) {                                                               \
+        if (str_to_int64(str, end, INT_MIN, INT_MAX, &parsed) < 0) {                \
             if (pconfig->allow_float_for_int) {                                     \
                 double fx;                                                          \
                 Py_UCS4 decimal = pconfig->decimal;                                 \
@@ -35,6 +34,9 @@
                 return -1;                                                          \
             }                                                                       \
         }                                                                           \
+        else {                                                                      \
+            x = (intw##_t)parsed;                                                   \
+        }                                                                           \
         memcpy(dataptr, &x, sizeof(x));                                             \
         if (!PyArray_ISNBO(descr->byteorder)) {                                     \
             descr->f->copyswap(dataptr, dataptr, 1, NULL);                          \
@@ -48,11 +50,10 @@
             const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,                  \
             parser_config *pconfig)                                                 \
     {                                                                               \
+        uint64_t parsed;                                                            \
         uintw##_t x;                                                                \
-        int ierror = 0;                                                             \
                                                                                     \
-        x = (uintw##_t) str_to_uint64(str, UINT_MAX, &ierror);                      \
-        if (ierror) {                                                               \
+        if (str_to_uint64(str, end, UINT_MAX, &parsed) < 0) {                       \
             if (pconfig->allow_float_for_int) {                                     \
                 double fx;                                                          \
                 Py_UCS4 decimal = pconfig->decimal;                                 \
@@ -67,6 +68,9 @@
             else {                                                                  \
                 return -1;                                                          \
             }                                                                       \
+        }                                                                           \
+        else {                                                                      \
+            x = (uintw##_t)parsed;                                                  \
         }                                                                           \
         memcpy(dataptr, &x, sizeof(x));                                             \
         if (!PyArray_ISNBO(descr->byteorder)) {                                     \


### PR DESCRIPTION
This partially fixes integer parsing to use the end information
rather than relying on NUL termination.
Fixes a bug (but misses a test yet) that embedded NUL bytes should
cause an error rather than silently ignore what follows.

The float path is not yet fixed though, but a partial step seemed
good.