### PR TITLE
BUG: Fixup stray NUL characters in complex

### DIFF
--- a/src/conversions.h
+++ b/src/conversions.h
@@ -20,10 +20,6 @@ to_float(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,
         parser_config *pconfig);
 
-/* Note: Currently used in the iteger code as a fallback */
-bool
-to_double_raw(const Py_UCS4 *str, double *res, Py_UCS4 decimal, Py_UCS4 sci);
-
 int
 to_double(PyArray_Descr *descr,
         const Py_UCS4 *str, const Py_UCS4 *end, char *dataptr,


### PR DESCRIPTION
Also simplifies the double code: Since it is fortified against
stray NUL characters, there is no need to check whether the string
is empty up-front.

This further fixes leading (and trailing non-space) whitespaces
which come before or after the the parentheses of the complex
number.

---

Fixes gh-42 although does not add tests.

