### PR TITLE
MAINT: Remove itemsize from fieldtypes (and fix some comments)

### DIFF
--- a/src/_readtextmodule.c
+++ b/src/_readtextmodule.c
@@ -106,8 +106,7 @@ parse_control_character(PyObject *obj, Py_UCS4 *character)
         return 0;
     }
     if (PyUnicode_GET_LENGTH(obj) == 0) {
-        /* TODO: This sets it to a non-existing character, could use NUL */
-        *character = (Py_UCS4)-1;
+        *character = (Py_UCS4)-1;  /* character beyond unicode range */
         return 1;
     }
     *character = PyUnicode_READ_CHAR(obj, 0);
@@ -177,7 +176,6 @@ _readtext_from_file_object(PyObject *self, PyObject *args, PyObject *kwargs)
     pc.c_byte_converters = c_byte_converters;
 
     if (pc.delimiter == (Py_UCS4)-1) {
-        /* TODO: We can allow a '\0' delimiter; need to refine argparsing */
         pc.delimiter_is_whitespace = true;
         /* Ignore leading whitespace to match `string.split(None)` */
         pc.ignore_leading_whitespace = true;

--- a/src/conversions.c
+++ b/src/conversions.c
@@ -20,7 +20,6 @@ _Py_dg_strtod_modified(
 
 /*
  * Coercion to boolean is done via integer right now.
- * TODO: Like the integer code, does not handle embedded \0 characters!
  */
 int
 to_bool(PyArray_Descr *NPY_UNUSED(descr),

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -39,7 +39,6 @@ field_types_create(int num_field_types, PyArray_Descr *dtypes[])
     }
     for (int i = 0; i < num_field_types; ++i) {
         PyArray_Descr *descr = dtypes[i];
-        ft[i].itemsize = descr->elsize;
         Py_INCREF(descr);
         ft[i].descr = descr;
 
@@ -47,7 +46,7 @@ field_types_create(int num_field_types, PyArray_Descr *dtypes[])
             ft[i].set_from_ucs4 = &to_bool;
         }
         else if (PyDataType_ISSIGNED(descr)) {
-            switch (ft[i].itemsize) {
+            switch (descr->elsize) {
                 case 1:
                     ft[i].set_from_ucs4 = &to_int8;
                     break;
@@ -65,7 +64,7 @@ field_types_create(int num_field_types, PyArray_Descr *dtypes[])
             }
         }
         else if (PyDataType_ISUNSIGNED(descr)) {
-            switch (ft[i].itemsize) {
+            switch (descr->elsize) {
                 case 1:
                     ft[i].set_from_ucs4 = &to_uint8;
                     break;

--- a/src/field_types.h
+++ b/src/field_types.h
@@ -17,7 +17,7 @@
  *
  * This function must support unaligned memory access.
  *
- * TODO: An earlier version of the code had unused default versions (pandas
+ * NOTE: An earlier version of the code had unused default versions (pandas
  *       does this) when columns are missing.  We could define this either
  *       by passing `NULL` in, or by adding a default explicitly somewhere.
  *       (I think users should probably have to define the default, at which
@@ -25,7 +25,7 @@
  *
  * NOTE: We are currently passing the parser config, this could be made public
  *       or could be set up to be dtype specific/private.  Always passing
- *       pconfig fully seems easier right now.
+ *       pconfig fully seems easier right now even if it may change.
  */
 typedef int (set_from_ucs4_function)(
         PyArray_Descr *descr, const Py_UCS4 *str, const Py_UCS4 *end,
@@ -35,12 +35,6 @@ typedef struct _field_type {
     set_from_ucs4_function *set_from_ucs4;
     /* The original NumPy descriptor */
     PyArray_Descr *descr;
-
-    // itemsize:
-    //   Size of field, in bytes.  In theory this would only be
-    //   needed for the 'S' or 'U' type codes, but it is expected to be
-    //   correctly filled in for all the types.
-    size_t itemsize;
 } field_type;
 
 

--- a/src/rows.c
+++ b/src/rows.c
@@ -41,12 +41,12 @@ compute_row_size(
     // rowsize is the number of bytes in each "row" of the array
     // filled in by this function.
     if (num_field_types == 1) {
-        row_size = actual_num_fields * field_types[0].itemsize;
+        row_size = actual_num_fields * field_types[0].descr->elsize;
     }
     else {
         row_size = 0;
         for (int k = 0; k < num_field_types; ++k) {
-            row_size += field_types[k].itemsize;
+            row_size += field_types[k].descr->elsize;
         }
     }
     return row_size;
@@ -379,7 +379,7 @@ read_rows(stream *s,
                     err = true;
                 }
             }
-            data_ptr += field_types[f].itemsize;
+            data_ptr += field_types[f].descr->elsize;
 
             if (NPY_UNLIKELY(err)) {
                 PyObject *exc, *val, *tb;


### PR DESCRIPTION
This mainly removes itemsize from field-types.  There seems no
reason for including it, and in fact, on my first check it was
even slightly faster not to...
Otherwise, just fixes some out-dated/wrong TODO comments