### PR TITLE
BUG: Move struct-dtype flattening to C and fix offsets

### DIFF
--- a/npreadtext/_readers.py
+++ b/npreadtext/_readers.py
@@ -216,20 +216,6 @@ def read(fname, *, delimiter=',', comment='#', quote='"',
         # Passing -1 to the C code means "read the entire file".
         max_rows = -1
 
-    # Compute `codes` and `sizes`.  These are derived from `dtype`, and we
-    # also pass `dtype` to the C function, so we're passing in redundant
-    # information.  This is because it is easier to write the code that
-    # creates `codes` and `sizes` using Python than C.
-    if dtype is not None:
-        dtypes = np.lib._iotools.flatten_dtype(dtype, flatten_base=True)
-        if (len(dtypes) != 1 and usecols is not None and
-                len(dtypes) != len(usecols)):
-            raise ValueError(f"length of usecols ({len(usecols)}) and "
-                             f"number of fields in dtype ({len(codes)}) "
-                             "do not match.")
-    else:
-        dtypes = None
-
     fh_closing_ctx = contextlib.nullcontext()
     filelike = False
     try:
@@ -265,7 +251,7 @@ def read(fname, *, delimiter=',', comment='#', quote='"',
                     data, delimiter=delimiter, comment=comment, quote=quote,
                     decimal=decimal, sci=sci, imaginary_unit=imaginary_unit,
                     usecols=usecols, skiprows=skiprows, max_rows=max_rows,
-                    converters=converters, dtype=dtype, dtypes=dtypes,
+                    converters=converters, dtype=dtype,
                     encoding=encoding, filelike=filelike,
                     byte_converters=byte_converters)
 
@@ -292,7 +278,7 @@ def read(fname, *, delimiter=',', comment='#', quote='"',
                         data, delimiter=delimiter, comment=comment, quote=quote,
                         decimal=decimal, sci=sci, imaginary_unit=imaginary_unit,
                         usecols=usecols, skiprows=skiprows, max_rows=max_rows,
-                        converters=converters, dtype=dtype, dtypes=dtypes,
+                        converters=converters, dtype=dtype,
                         encoding=encoding, filelike=filelike,
                         byte_converters=byte_converters,
                         c_byte_converters=c_byte_converters)

--- a/npreadtext/tests/test_read.py
+++ b/npreadtext/tests/test_read.py
@@ -140,6 +140,25 @@ def test_structured_dtype_2():
     assert_array_equal(a, np.array([(((0, 1), (2, 3)),)], dtype=dt))
 
 
+def test_nested_structured_subarray():
+    # Test from numpygh-16678
+    point = np.dtype([('x', float), ('y', float)])
+    dt = np.dtype([('code', int), ('points', point, (2,))])
+    res = read(StringIO('100,1,2,3,4\n200,5,6,7,8\n'), dtype=dt)
+
+    expected = np.array([(100, [(1., 2.), (3., 4.)]),
+                         (200, [(5., 6.), (7., 8.)])], dtype=dt)
+    assert_array_equal(res, expected)
+
+
+def test_structured_dtypes_offsets():
+    # An aligned structured dtype will have additional padding:
+    dt = np.dtype("i1,i4,i1,i4,i1,i4", align=True)
+    res = read(StringIO('1,2,3,4,5,6\n7,8,9,10,11,12\n'), dtype=dt)
+
+    expected = np.array([(1, 2, 3, 4, 5, 6), (7, 8, 9, 10, 11, 12)], dtype=dt)
+    assert_array_equal(res, expected)
+
 @pytest.mark.parametrize('param', ['skiprows', 'max_rows'])
 @pytest.mark.parametrize('badval, exc', [(-3, ValueError), (1.0, TypeError)])
 def test_bad_nonneg_int(param, badval, exc):

--- a/src/field_types.c
+++ b/src/field_types.c
@@ -4,11 +4,14 @@
 
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL npreadtext_ARRAY_API
-#include <numpy/arrayobject.h>
+#include <numpy/ndarraytypes.h>
+
+#include "growth.h"
 
 
 void
 field_types_xclear(int num_field_types, field_type *ft) {
+    assert(num_field_types >= 0);
     if (ft == NULL) {
         return;
     }
@@ -21,87 +24,176 @@ field_types_xclear(int num_field_types, field_type *ft) {
 
 
 /*
+ * Fetch custom converters for the builtin NumPy DTypes (or the generic one).
+ * Structured DTypes get unpacked and `object` uses the generic method.
+ *
+ * TODO: This should probably be moved on the DType object in some form,
+ *       to allow user DTypes to define their own converters.
+ */
+static set_from_ucs4_function *
+get_from_ucs4_function(PyArray_Descr *descr)
+{
+    if (descr->type_num == NPY_BOOL) {
+        return &to_bool;
+    }
+    else if (PyDataType_ISSIGNED(descr)) {
+        switch (descr->elsize) {
+            case 1:
+                return &to_int8;
+            case 2:
+                return &to_int16;
+            case 4:
+                return &to_int32;
+            case 8:
+                return &to_int64;
+            default:
+                assert(0);
+        }
+    }
+    else if (PyDataType_ISUNSIGNED(descr)) {
+        switch (descr->elsize) {
+            case 1:
+                return &to_uint8;
+            case 2:
+                return &to_uint16;
+            case 4:
+                return &to_uint32;
+            case 8:
+                return &to_uint64;
+            default:
+                assert(0);
+        }
+    }
+    else if (descr->type_num == NPY_FLOAT) {
+        return &to_float;
+    }
+    else if (descr->type_num == NPY_DOUBLE) {
+        return &to_double;
+    }
+    else if (descr->type_num == NPY_CFLOAT) {
+        return &to_cfloat;
+    }
+    else if (descr->type_num == NPY_CDOUBLE) {
+        return &to_cdouble;
+    }
+    else if (descr->type_num == NPY_STRING) {
+        return &to_string;
+    }
+    else if (descr->type_num == NPY_UNICODE) {
+        return &to_unicode;
+    }
+    return &to_generic;
+}
+
+
+/*
+ * Note that the function cleans up `ft` on error.  If `num_field_types < 0`
+ * cleanup has already happened in the internal call.
+ */
+static npy_intp
+field_type_grow_recursive(PyArray_Descr *descr,
+        npy_intp num_field_types, field_type **ft, npy_intp *ft_size,
+        npy_intp field_offset)
+{
+    if (PyDataType_HASSUBARRAY(descr)) {
+        PyArray_Dims shape = {NULL, -1};
+
+        if (!(PyArray_IntpConverter(descr->subarray->shape, &shape))) {
+             PyErr_SetString(PyExc_ValueError, "invalid subarray shape");
+             field_types_xclear(num_field_types, *ft);
+             return -1;
+        }
+        npy_intp size = PyArray_MultiplyList(shape.ptr, shape.len);
+        free(shape.ptr);  /* TODO: Use `npy_free_cache_dim_obj` (in NumPy) */
+        for (npy_intp i = 0; i < size; i++) {
+            num_field_types = field_type_grow_recursive(descr->subarray->base,
+                    num_field_types, ft, ft_size, field_offset);
+            field_offset += descr->subarray->base->elsize;
+            if (num_field_types < 0) {
+                return -1;
+            }
+        }
+        return num_field_types;
+    }
+    else if (PyDataType_HASFIELDS(descr)) {
+        npy_int num_descr_fields = PyTuple_Size(descr->names);
+        if (num_descr_fields < 0) {
+            field_types_xclear(num_field_types, *ft);
+            return -1;
+        }
+        for (npy_intp i = 0; i < num_descr_fields; i++) {
+            PyObject *key = PyTuple_GET_ITEM(descr->names, i);
+            PyObject *tup = PyObject_GetItem(descr->fields, key);
+            if (tup == NULL) {
+                field_types_xclear(num_field_types, *ft);
+                return -1;
+            }
+            PyArray_Descr *field_descr;
+            PyObject *title;
+            int offset;
+            if (!PyArg_ParseTuple(tup, "Oi|O", &field_descr, &offset, &title)) {
+                Py_DECREF(tup);
+                field_types_xclear(num_field_types, *ft);
+                return -1;
+            }
+            num_field_types = field_type_grow_recursive(
+                    field_descr, num_field_types, ft, ft_size,
+                    field_offset + offset);
+            if (num_field_types < 0) {
+                return -1;
+            }
+        }
+        return num_field_types;
+    }
+
+    if (*ft_size <= num_field_types) {
+        npy_intp alloc_size = grow_size_and_multiply(
+                ft_size, 4, sizeof(field_type));
+        if (alloc_size < 0) {
+            field_types_xclear(num_field_types, *ft);
+            return -1;
+        }
+        field_type *new_ft = PyMem_Realloc(*ft, alloc_size);
+        if (new_ft == NULL) {
+            field_types_xclear(num_field_types, *ft);
+            return -1;
+        }
+        *ft = new_ft;
+    }
+
+    Py_INCREF(descr);
+    (*ft)[num_field_types].descr = descr;
+    (*ft)[num_field_types].set_from_ucs4 = get_from_ucs4_function(descr);
+    (*ft)[num_field_types].structured_offset = field_offset;
+
+    return num_field_types + 1;
+}
+
+
+/*
  * Prepare the "field_types" for the given dtypes/descriptors.  Currently,
  * we copy the itemsize, but the main thing is that we check for custom
  * converters.
- * TODO: As soon as we move this into NumPy we could move the conversion
- *       function onto the DType.  At this point, this would not be used or
- *       only used as a fast storage.
  */
-field_type *
-field_types_create(int num_field_types, PyArray_Descr *dtypes[])
+npy_intp
+field_types_create(PyArray_Descr *descr, field_type **ft)
 {
-    field_type *ft;
+    if (descr->subarray != NULL) {
+        /*
+         * This could probably be allowed, but NumPy absorbs the dimensions
+         * so it is an awkward corner case that probably never really worked.
+         */
+        PyErr_SetString(PyExc_TypeError,
+                "file reader does not support subarray dtypes.  You can"
+                "put the dtype into a structured one using "
+                "`np.dtype(('name', dtype))` to avoid this limitation.");
+        return -1;
+    }
 
-    ft = PyMem_Malloc(num_field_types * sizeof(field_type));
+    npy_intp ft_size = 4;
+    *ft = PyMem_Malloc(ft_size * sizeof(field_type));
     if (ft == NULL) {
-        return NULL;
+        return -1;
     }
-    for (int i = 0; i < num_field_types; ++i) {
-        PyArray_Descr *descr = dtypes[i];
-        Py_INCREF(descr);
-        ft[i].descr = descr;
-
-        if (descr->type_num == NPY_BOOL) {
-            ft[i].set_from_ucs4 = &to_bool;
-        }
-        else if (PyDataType_ISSIGNED(descr)) {
-            switch (descr->elsize) {
-                case 1:
-                    ft[i].set_from_ucs4 = &to_int8;
-                    break;
-                case 2:
-                    ft[i].set_from_ucs4 = &to_int16;
-                    break;
-                case 4:
-                    ft[i].set_from_ucs4 = &to_int32;
-                    break;
-                case 8:
-                    ft[i].set_from_ucs4 = &to_int64;
-                    break;
-                default:
-                    assert(0);
-            }
-        }
-        else if (PyDataType_ISUNSIGNED(descr)) {
-            switch (descr->elsize) {
-                case 1:
-                    ft[i].set_from_ucs4 = &to_uint8;
-                    break;
-                case 2:
-                    ft[i].set_from_ucs4 = &to_uint16;
-                    break;
-                case 4:
-                    ft[i].set_from_ucs4 = &to_uint32;
-                    break;
-                case 8:
-                    ft[i].set_from_ucs4 = &to_uint64;
-                    break;
-                default:
-                    assert(0);
-            }
-        }
-        else if (descr->type_num == NPY_FLOAT) {
-            ft[i].set_from_ucs4 = &to_float;
-        }
-        else if (descr->type_num == NPY_DOUBLE) {
-            ft[i].set_from_ucs4 = &to_double;
-        }
-        else if (descr->type_num == NPY_CFLOAT) {
-            ft[i].set_from_ucs4 = &to_cfloat;
-        }
-        else if (descr->type_num == NPY_CDOUBLE) {
-            ft[i].set_from_ucs4 = &to_cdouble;
-        }
-        else if (descr->type_num == NPY_STRING) {
-            ft[i].set_from_ucs4 = &to_string;
-        }
-        else if (descr->type_num == NPY_UNICODE) {
-            ft[i].set_from_ucs4 = &to_unicode;
-        }
-        else {
-            ft[i].set_from_ucs4 = &to_generic;
-        }
-    }
-    return ft;
+    return field_type_grow_recursive(descr, 0, ft, &ft_size, 0);
 }

--- a/src/field_types.h
+++ b/src/field_types.h
@@ -35,13 +35,15 @@ typedef struct _field_type {
     set_from_ucs4_function *set_from_ucs4;
     /* The original NumPy descriptor */
     PyArray_Descr *descr;
+    /* Offset to this entry within row. */
+    npy_intp structured_offset;
 } field_type;
 
 
 void
 field_types_xclear(int num_field_types, field_type *ft);
 
-field_type *
-field_types_create(int num_field_types, PyArray_Descr *dtypes[]);
+npy_intp
+field_types_create(PyArray_Descr *descr, field_type **ft);
 
 #endif

--- a/src/parser_config.h
+++ b/src/parser_config.h
@@ -2,14 +2,12 @@
 #ifndef _PARSER_CONFIG_H_
 #define _PARSER_CONFIG_H_
 
-#include <stdint.h>
 #include <stdbool.h>
 
-
-typedef struct _parser_config {
+typedef struct {
     /*
      *  Field delimiter character.
-     *  Typically ',', ' ', '\t', or '\0'.
+     *  Typically ',', ' ', '\t', ignored if `delimiter_is_whitespace` is true.
      */
     Py_UCS4 delimiter;
 
@@ -22,24 +20,25 @@ typedef struct _parser_config {
     Py_UCS4 quote;
 
     /*
-     *  Ignore whitespace at the beginning of a field (outside/before quotes).
-     *  Is implicitly always set if we split on any whitespace.
-     */
-    bool ignore_leading_whitespace;
-
-    /*
-     * If true, the delimiter is ignored and any unicode whitespace is used
-     * for splitting (same as `string.split()` in Python).
-     */
-    bool delimiter_is_whitespace;
-
-    /*
      *  Character(s) that indicates the start of a comment.
      *  Typically '#', '%' or ';'.
      *  When encountered in a line and not inside quotes, all character
      *  from the comment character(s) to the end of the line are ignored.
      */
     Py_UCS4 comment;
+
+    /*
+     *  Ignore whitespace at the beginning of a field (outside/before quotes).
+     *  Is (and must be) set if `delimiter_is_whitespace`.
+     */
+    bool ignore_leading_whitespace;
+
+    /*
+     * If true, the delimiter is ignored and any unicode whitespace is used
+     * for splitting (same as `string.split()` in Python). In that case
+     * `ignore_leading_whitespace` should also be set.
+     */
+    bool delimiter_is_whitespace;
 
     /*
      *  A boolean value (0 or 1).  If 1, quoted fields may span
@@ -87,7 +86,5 @@ typedef struct _parser_config {
      bool c_byte_converters;
 } parser_config;
 
-parser_config
-default_parser_config(void);
 
 #endif

--- a/src/rows.h
+++ b/src/rows.h
@@ -13,7 +13,7 @@
 
 PyArrayObject *
 read_rows(stream *s,
-        Py_ssize_t *nrows, int num_field_types, field_type *field_types,
+        npy_intp nrows, int num_field_types, field_type *field_types,
         parser_config *pconfig, int num_usecols, int *usecols,
         Py_ssize_t skiplines, PyObject *converters,
         PyArrayObject *data_array, PyArray_Descr *out_descr,

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -33,7 +33,6 @@ typedef struct {
 
 typedef struct {
     tokenizer_parsing_state state;
-    bool ignore_leading_whitespace;
     /* Either TOKENIZE_UNQUOTED or TOKENIZE_UNQUOTED_WHITESPACE: */
     tokenizer_parsing_state unquoted_state;
     int unicode_kind;


### PR DESCRIPTION
This fixes the offset handling into structured dtypes by moving
the dtype flattening code to C.
By doing that, it also fixes gh-75 and gh-94.

At the time adds a (harmless) compiler warning which should be
removed, but I may just put this in without fixing it.